### PR TITLE
Interrupt the Workflow on reload

### DIFF
--- a/src/component/classes/adapterContext.ts
+++ b/src/component/classes/adapterContext.ts
@@ -104,8 +104,8 @@ export class AdapterContext {
     if (this.isInitialized) {
       return;
     }
-    const { state, buffer, logger, callWorkflow } = scroller;
-    this.callWorkflow = callWorkflow;
+    const { state, buffer, logger, workflow } = scroller;
+    this.callWorkflow = workflow.call;
     this.logger = logger;
 
     this.getVersion = (): string | null => scroller.version;

--- a/src/component/interfaces/index.ts
+++ b/src/component/interfaces/index.ts
@@ -3,7 +3,7 @@ import { ItemAdapter, ItemsPredicate, ClipOptions, Adapter } from './adapter';
 import { Settings, DevSettings } from './settings';
 import { Direction } from './direction';
 import { WindowScrollState, ScrollEventData, ScrollState, SyntheticScroll, WorkflowOptions, State } from './state';
-import { Process, ProcessStatus, ScrollPayload, ProcessSubject, WorkflowError, CallWorkflow, ScrollerWorkflow } from './process';
+import { Process, ProcessStatus, ScrollPayload, ProcessSubject, WorkflowError, ScrollerWorkflow } from './process';
 
 export {
   Datasource,
@@ -26,6 +26,5 @@ export {
   ScrollPayload,
   ProcessSubject,
   WorkflowError,
-  CallWorkflow,
   ScrollerWorkflow
 };

--- a/src/component/interfaces/index.ts
+++ b/src/component/interfaces/index.ts
@@ -3,28 +3,29 @@ import { ItemAdapter, ItemsPredicate, ClipOptions, Adapter } from './adapter';
 import { Settings, DevSettings } from './settings';
 import { Direction } from './direction';
 import { WindowScrollState, ScrollEventData, ScrollState, SyntheticScroll, WorkflowOptions, State } from './state';
-import { Process, ProcessStatus, ScrollPayload, ProcessSubject, CallWorkflow, WorkflowError } from './process';
+import { Process, ProcessStatus, ScrollPayload, ProcessSubject, WorkflowError, CallWorkflow, ScrollerWorkflow } from './process';
 
 export {
   Datasource,
   DatasourceGet,
-  Direction,
+  ItemAdapter,
+  ItemsPredicate,
+  ClipOptions,
+  Adapter,
   Settings,
   DevSettings,
-  Process,
-  ProcessStatus,
-  ScrollPayload,
-  ProcessSubject,
-  CallWorkflow,
-  WorkflowError,
+  Direction,
   WindowScrollState,
   ScrollEventData,
   ScrollState,
   SyntheticScroll,
   WorkflowOptions,
   State,
-  ItemAdapter,
-  ItemsPredicate,
-  ClipOptions,
-  Adapter
+  Process,
+  ProcessStatus,
+  ScrollPayload,
+  ProcessSubject,
+  WorkflowError,
+  CallWorkflow,
+  ScrollerWorkflow
 };

--- a/src/component/interfaces/process.ts
+++ b/src/component/interfaces/process.ts
@@ -43,8 +43,6 @@ export interface WorkflowError {
   process: Process;
 }
 
-export type CallWorkflow = (processSubject: ProcessSubject) => void;
-
 export interface ScrollerWorkflow {
-  call: CallWorkflow;
+  call: Function;
 }

--- a/src/component/interfaces/process.ts
+++ b/src/component/interfaces/process.ts
@@ -43,4 +43,8 @@ export interface WorkflowError {
   process: Process;
 }
 
-export type CallWorkflow = (processSubject: ProcessSubject) => undefined;
+export type CallWorkflow = (processSubject: ProcessSubject) => void;
+
+export interface ScrollerWorkflow {
+  call: CallWorkflow;
+}

--- a/src/component/processes/adjust.ts
+++ b/src/component/processes/adjust.ts
@@ -6,17 +6,18 @@ export default class Adjust {
   static MAX_SCROLL_ADJUSTMENTS_COUNT = 10;
 
   static run(scroller: Scroller) {
-    scroller.state.preAdjustPosition = scroller.viewport.scrollPosition;
+    const { workflow, state, viewport } = scroller;
+    state.preAdjustPosition = viewport.scrollPosition;
 
     // padding-elements adjustments
     const setPaddingsResult =
       Adjust.setPaddings(scroller);
 
     if (setPaddingsResult === false) {
-      scroller.callWorkflow({
+      workflow.call({
         process: Process.adjust,
         status: ProcessStatus.error,
-        payload: { error: 'Can\'t get visible item' }
+        payload: { error: `Can't get visible item` }
       });
       return;
     }
@@ -24,7 +25,7 @@ export default class Adjust {
     // scroll position adjustments
     Adjust.fixScrollPosition(scroller, <number>setPaddingsResult);
 
-    scroller.callWorkflow({
+    workflow.call({
       process: Process.adjust,
       status: ProcessStatus.done
     });

--- a/src/component/processes/append.ts
+++ b/src/component/processes/append.ts
@@ -5,6 +5,7 @@ import { Process, ProcessStatus } from '../interfaces/index';
 export default class Append {
 
   static run(scroller: Scroller, payload: { items: any, eof?: any, bof?: any, prepend?: any }) {
+    const { workflow } = scroller;
     let { items } = payload;
     items = !Array.isArray(items) ? [items] : items;
     const prepend = !!payload.prepend;
@@ -12,7 +13,7 @@ export default class Append {
     const process = prepend ? Process.prepend : Process.append;
 
     if (!items.length) {
-      scroller.callWorkflow({
+      workflow.call({
         process,
         status: ProcessStatus.error,
         payload: { error: `Wrong argument of the "${prepend ? 'prepend' : 'append'}" method call` }
@@ -26,7 +27,7 @@ export default class Append {
       (!prepend && eof && !scroller.buffer.eof)
     ) {
       Append.doVirtualize(scroller, items, prepend);
-      scroller.callWorkflow({
+      workflow.call({
         process,
         status: ProcessStatus.done
       });
@@ -34,7 +35,7 @@ export default class Append {
     }
 
     Append.simulateFetch(scroller, items, eof, prepend);
-    scroller.callWorkflow({
+    workflow.call({
       process,
       status: ProcessStatus.next
     });

--- a/src/component/processes/check.ts
+++ b/src/component/processes/check.ts
@@ -4,7 +4,7 @@ import { Process, ProcessStatus } from '../interfaces/index';
 export default class Check {
 
   static run(scroller: Scroller) {
-    const { buffer, state: { fetch } } = scroller;
+    const { workflow, buffer, state: { fetch } } = scroller;
     let min = Number.POSITIVE_INFINITY, max = Number.NEGATIVE_INFINITY;
 
     buffer.items.forEach(item => {
@@ -28,7 +28,7 @@ export default class Check {
 
     scroller.logger.stat('check');
 
-    scroller.callWorkflow({
+    workflow.call({
       process: Process.check,
       status: Number.isFinite(min) ? ProcessStatus.next : ProcessStatus.done
     });

--- a/src/component/processes/clip.ts
+++ b/src/component/processes/clip.ts
@@ -4,14 +4,14 @@ import { Process, ProcessStatus, Direction } from '../interfaces/index';
 export default class Clip {
 
   static run(scroller: Scroller) {
-    const { clip } = scroller.state;
+    const { workflow, state: { clip } } = scroller;
     if (clip.doClip) {
       Clip.doClip(scroller);
     } else {
       scroller.logger.log(() => 'no clip');
     }
 
-    scroller.callWorkflow({
+    workflow.call({
       process: Process.clip,
       status: ProcessStatus.next,
       ...(clip.simulate ? { payload: Process.end } : {})

--- a/src/component/processes/end.ts
+++ b/src/component/processes/end.ts
@@ -43,7 +43,6 @@ export default class End {
 
   static endWorkflowLoop(scroller: Scroller, next: boolean) {
     const { state, state: { clip } } = scroller;
-    state.loopPending = false;
     state.countDone++;
     state.isInitialLoop = false;
     state.fetch.simulate = false;
@@ -51,6 +50,7 @@ export default class End {
     clip.forceReset();
     state.lastPosition = scroller.viewport.scrollPosition;
     scroller.purgeInnerLoopSubscriptions();
+    state.loopPending = false;
   }
 
   static calculateParams(scroller: Scroller) {

--- a/src/component/processes/end.ts
+++ b/src/component/processes/end.ts
@@ -15,6 +15,11 @@ export default class End {
       End.calculateParams(scroller);
     }
 
+    // explicit interruption for we don't want go through the workflow loop finalizing
+    if ((<any>workflow.call).interrupted) {
+      return workflow.call();
+    }
+
     // what next? done?
     const next = End.getNext(scroller, process, error);
 

--- a/src/component/processes/fetch.ts
+++ b/src/component/processes/fetch.ts
@@ -28,14 +28,14 @@ export default class Fetch {
       `(index = ${scroller.state.fetch.index}, count = ${scroller.state.fetch.count})`);
     scroller.state.fetch.newItemsData = data;
 
-    scroller.callWorkflow({
+    scroller.workflow.call({
       process: Process.fetch,
       status: ProcessStatus.next
     });
   }
 
   static fail(error: string, scroller: Scroller) {
-    scroller.callWorkflow({
+    scroller.workflow.call({
       process: Process.fetch,
       status: ProcessStatus.error,
       payload: { error }

--- a/src/component/processes/fetch.ts
+++ b/src/component/processes/fetch.ts
@@ -6,40 +6,41 @@ import { Process, ProcessStatus } from '../interfaces/index';
 export default class Fetch {
 
   static run(scroller: Scroller) {
+    const { workflow } = scroller;
+
+    function success(data: Array<any>) {
+      scroller.logger.log(() => `resolved ${data.length} items ` +
+        `(index = ${scroller.state.fetch.index}, count = ${scroller.state.fetch.count})`);
+      scroller.state.fetch.newItemsData = data;
+      workflow.call({
+        process: Process.fetch,
+        status: ProcessStatus.next
+      });
+    }
+
+    function fail(error: string) {
+      workflow.call({
+        process: Process.fetch,
+        status: ProcessStatus.error,
+        payload: { error }
+      });
+    }
+
     const result = Fetch.get(scroller);
     if (typeof result.subscribe !== 'function') {
       if (!result.isError) {
-        Fetch.success(result.data, scroller);
+        success(result.data);
       } else {
-        Fetch.fail(result.error, scroller);
+        fail(result.error);
       }
     } else {
       scroller.innerLoopSubscriptions.push(
         result.subscribe(
-          (data: Array<any>) => Fetch.success(data, scroller),
-          (error: any) => Fetch.fail(error, scroller)
+          (data: Array<any>) => success(data),
+          (error: any) => fail(error)
         )
       );
     }
-  }
-
-  static success(data: Array<any>, scroller: Scroller) {
-    scroller.logger.log(() => `resolved ${data.length} items ` +
-      `(index = ${scroller.state.fetch.index}, count = ${scroller.state.fetch.count})`);
-    scroller.state.fetch.newItemsData = data;
-
-    scroller.workflow.call({
-      process: Process.fetch,
-      status: ProcessStatus.next
-    });
-  }
-
-  static fail(error: string, scroller: Scroller) {
-    scroller.workflow.call({
-      process: Process.fetch,
-      status: ProcessStatus.error,
-      payload: { error }
-    });
   }
 
   static get(scroller: Scroller) {

--- a/src/component/processes/init.ts
+++ b/src/component/processes/init.ts
@@ -4,14 +4,14 @@ import { Process, ProcessStatus } from '../interfaces/index';
 export default class Init {
 
   static run(scroller: Scroller, process?: Process) {
-    const { state } = scroller;
+    const { state, workflow } = scroller;
     const isInitial = !process || process === Process.reload;
     scroller.logger.logCycle(true);
     state.isInitialWorkflowCycle = isInitial;
     state.isInitialLoop = isInitial;
     state.workflowPending = true;
     state.isLoading = true;
-    scroller.callWorkflow({
+    workflow.call({
       process: Process.init,
       status: ProcessStatus.next,
       payload: process || Process.init

--- a/src/component/processes/postFetch.ts
+++ b/src/component/processes/postFetch.ts
@@ -5,16 +5,17 @@ import { Process, ProcessStatus } from '../interfaces/index';
 export default class PostFetch {
 
   static run(scroller: Scroller) {
+    const { workflow } = scroller;
     if (PostFetch.setItems(scroller)) {
       PostFetch.setBufferLimits(scroller);
-      scroller.workflow.call({
+      workflow.call({
         process: Process.postFetch,
         status: scroller.state.fetch.hasNewItems
           ? ProcessStatus.next
           : ProcessStatus.done
       });
     } else {
-      scroller.workflow.call({
+      workflow.call({
         process: Process.postFetch,
         status: ProcessStatus.error,
         payload: { error: `Can't set buffer items` }

--- a/src/component/processes/postFetch.ts
+++ b/src/component/processes/postFetch.ts
@@ -7,15 +7,17 @@ export default class PostFetch {
   static run(scroller: Scroller) {
     if (PostFetch.setItems(scroller)) {
       PostFetch.setBufferLimits(scroller);
-      scroller.callWorkflow({
+      scroller.workflow.call({
         process: Process.postFetch,
-        status: scroller.state.fetch.hasNewItems ? ProcessStatus.next : ProcessStatus.done
+        status: scroller.state.fetch.hasNewItems
+          ? ProcessStatus.next
+          : ProcessStatus.done
       });
     } else {
-      scroller.callWorkflow({
+      scroller.workflow.call({
         process: Process.postFetch,
         status: ProcessStatus.error,
-        payload: { error: 'Can\'t set buffer items' }
+        payload: { error: `Can't set buffer items` }
       });
     }
   }

--- a/src/component/processes/preClip.ts
+++ b/src/component/processes/preClip.ts
@@ -6,7 +6,7 @@ export default class PreClip {
   static run(scroller: Scroller) {
     PreClip.prepareClip(scroller);
 
-    scroller.callWorkflow({
+    scroller.workflow.call({
       process: Process.preClip,
       status: ProcessStatus.next,
       payload: { doClip: scroller.state.clip.doClip }

--- a/src/component/processes/preFetch.ts
+++ b/src/component/processes/preFetch.ts
@@ -4,7 +4,7 @@ import { Process, ProcessStatus, Direction } from '../interfaces/index';
 export default class PreFetch {
 
   static run(scroller: Scroller, process: Process) {
-    const { buffer, state: { fetch } } = scroller;
+    const { workflow, buffer, state: { fetch } } = scroller;
     scroller.state.preFetchPosition = scroller.viewport.scrollPosition;
     fetch.minIndex = buffer.minIndex;
     fetch.averageItemSize = buffer.averageSize || 0;
@@ -33,7 +33,7 @@ export default class PreFetch {
       scroller.logger.log(() => `going to fetch ${fetch.count} items started from index ${fetch.index}`);
     }
 
-    scroller.callWorkflow({
+    workflow.call({
       process: Process.preFetch,
       status: fetch.shouldFetch ? ProcessStatus.next : ProcessStatus.done,
       payload: process

--- a/src/component/processes/reload.ts
+++ b/src/component/processes/reload.ts
@@ -13,7 +13,7 @@ export default class Reload {
       scroller.purgeScrollTimers();
       payload.finalize = true;
     }
-    scroller.callWorkflow({
+    scroller.workflow.call({
       process: Process.reload,
       status: ProcessStatus.next,
       payload

--- a/src/component/processes/remove.ts
+++ b/src/component/processes/remove.ts
@@ -5,7 +5,7 @@ export default class Remove {
 
   static run(scroller: Scroller, predicate: ItemsPredicate) {
     if (!Remove.checkPredicate(predicate)) {
-      scroller.callWorkflow({
+      scroller.workflow.call({
         process: Process.remove,
         status: ProcessStatus.error,
         payload: { error: `Wrong argument of the "Adapter.remove" method call` }
@@ -23,14 +23,14 @@ export default class Remove {
     });
 
     if (!scroller.state.clip.doClip) {
-      scroller.callWorkflow({
+      scroller.workflow.call({
         process: Process.remove,
         status: ProcessStatus.done
       });
       return;
     }
 
-    scroller.callWorkflow({
+    scroller.workflow.call({
       process: Process.remove,
       status: ProcessStatus.next
     });

--- a/src/component/processes/render.ts
+++ b/src/component/processes/render.ts
@@ -9,16 +9,16 @@ export default class Render {
     scroller.innerLoopSubscriptions.push(
       scroller.bindData().subscribe(() => {
         if (Render.processElements(scroller)) {
-          scroller.callWorkflow({
+          scroller.workflow.call({
             process: Process.render,
             status: ProcessStatus.next,
             payload: { noClip: scroller.state.clip.noClip }
           });
         } else {
-          scroller.callWorkflow({
+          scroller.workflow.call({
             process: Process.render,
             status: ProcessStatus.error,
-            payload: { error: 'Can\'t associate item with element' }
+            payload: { error: `Can't associate item with element` }
           });
         }
       })

--- a/src/component/processes/scroll.ts
+++ b/src/component/processes/scroll.ts
@@ -182,7 +182,7 @@ export default class Scroll {
     const skip = scroller.buffer.bof && scroller.buffer.eof;
     workflowOptions.scroll = true;
     workflowOptions.keepScroll = scrollState.keepScroll;
-    scroller.callWorkflow({
+    scroller.workflow.call({
       process: Process.scroll,
       status: skip ? ProcessStatus.done : ProcessStatus.next
     });

--- a/src/component/processes/start.ts
+++ b/src/component/processes/start.ts
@@ -16,7 +16,7 @@ export default class Start {
     scrollState.scroll = workflowOptions.scroll || false;
     scrollState.keepScroll = false;
 
-    scroller.callWorkflow({
+    scroller.workflow.call({
       process: Process.start,
       status: ProcessStatus.next,
       payload: process

--- a/src/component/processes/userClip.ts
+++ b/src/component/processes/userClip.ts
@@ -9,7 +9,7 @@ export default class UserClip {
     scroller.state.clip.forceForward = !_options.backwardOnly;
     scroller.state.clip.forceBackward = !_options.forwardOnly;
 
-    scroller.callWorkflow({
+    scroller.workflow.call({
       process: Process.userClip,
       status: ProcessStatus.next
     });

--- a/src/component/scroller.ts
+++ b/src/component/scroller.ts
@@ -9,14 +9,14 @@ import { Routines } from './classes/domRoutines';
 import { Viewport } from './classes/viewport';
 import { Buffer } from './classes/buffer';
 import { State } from './classes/state';
-import { CallWorkflow } from './interfaces/index';
+import { CallWorkflow, ScrollerWorkflow } from './interfaces/index';
 
 let instanceCount = 0;
 
 export class Scroller {
 
   readonly runChangeDetector: Function;
-  readonly callWorkflow: CallWorkflow;
+  public workflow: ScrollerWorkflow;
 
   public version: string;
   public datasource: Datasource;
@@ -36,7 +36,7 @@ export class Scroller {
 
     this.runChangeDetector = () => context.changeDetector.markForCheck();
     // this.runChangeDetector = () => context.changeDetector.detectChanges();
-    this.callWorkflow = callWorkflow;
+    this.workflow = { call: callWorkflow };
     this.innerLoopSubscriptions = [];
 
     this.settings = new Settings(datasource.settings, datasource.devSettings, ++instanceCount);

--- a/src/component/scroller.ts
+++ b/src/component/scroller.ts
@@ -9,7 +9,7 @@ import { Routines } from './classes/domRoutines';
 import { Viewport } from './classes/viewport';
 import { Buffer } from './classes/buffer';
 import { State } from './classes/state';
-import { CallWorkflow, ScrollerWorkflow } from './interfaces/index';
+import { ScrollerWorkflow } from './interfaces/index';
 
 let instanceCount = 0;
 
@@ -29,14 +29,14 @@ export class Scroller {
 
   public innerLoopSubscriptions: Array<Subscription>;
 
-  constructor(context: UiScrollComponent, callWorkflow: CallWorkflow) {
+  constructor(context: UiScrollComponent, callWorkflow: Function) {
     const datasource = <Datasource>checkDatasource(context.datasource);
     this.datasource = datasource;
     this.version = context.version;
 
     this.runChangeDetector = () => context.changeDetector.markForCheck();
     // this.runChangeDetector = () => context.changeDetector.detectChanges();
-    this.workflow = { call: callWorkflow };
+    this.workflow = <ScrollerWorkflow>{ call: callWorkflow };
     this.innerLoopSubscriptions = [];
 
     this.settings = new Settings(datasource.settings, datasource.devSettings, ++instanceCount);

--- a/src/component/workflow.ts
+++ b/src/component/workflow.ts
@@ -135,6 +135,7 @@ export class Workflow {
           run(Reload)(payload);
         }
         if (status === Status.next) {
+          this.interrupt();
           if (payload.finalize) {
             run(End)(process);
           } else {
@@ -286,6 +287,11 @@ export class Workflow {
     //   return ['%ccall%c', ...['color: #77cc77;', 'color: #000000;'], process, `"${status}"`, ...(payload ? [payload] : [])];
     // });
     this.process$.next(processSubject);
+  }
+
+  interrupt() {
+    this.scroller.workflow.call = () => null;
+    this.scroller.workflow = { call: this.callWorkflow };
   }
 
   done() {

--- a/src/component/workflow.ts
+++ b/src/component/workflow.ts
@@ -27,7 +27,8 @@ export class Workflow {
       process: Process.init,
       status: Status.start
     });
-    this.scroller = new Scroller(this.context, <CallWorkflow>this.callWorkflow.bind(this));
+    this.callWorkflow = <CallWorkflow>this.callWorkflow.bind(this);
+    this.scroller = new Scroller(this.context, this.callWorkflow);
     this.cyclesDone = 0;
     this.errors = [];
     this.onScrollHandler = event => Scroll.run(this.scroller, event);

--- a/src/component/workflow.ts
+++ b/src/component/workflow.ts
@@ -2,7 +2,7 @@ import { Subscription, BehaviorSubject } from 'rxjs';
 
 import { UiScrollComponent } from '../ui-scroll.component';
 import { Scroller } from './scroller';
-import { CallWorkflow, Process, ProcessStatus as Status, ProcessSubject, WorkflowError } from './interfaces/index';
+import { Process, ProcessStatus as Status, ProcessSubject, WorkflowError, ScrollerWorkflow } from './interfaces/index';
 import {
   Init, Scroll, Reload, Append, Check, Remove, UserClip,
   Start, PreFetch, Fetch, PostFetch, Render, PreClip, Clip, Adjust, End
@@ -28,7 +28,7 @@ export class Workflow {
       process: Process.init,
       status: Status.start
     });
-    this.callWorkflow = <CallWorkflow>this.callWorkflow.bind(this);
+    this.callWorkflow = <any>this.callWorkflow.bind(this);
     this.scroller = new Scroller(this.context, this.callWorkflow);
     this.cyclesDone = 0;
     this.interruptionCount = 0;
@@ -291,11 +291,12 @@ export class Workflow {
     this.process$.next(processSubject);
   }
 
-  interrupt(process: Process) {
+  interrupt(process?: Process) {
     const { scroller } = this;
     if (scroller.state.isLoading) {
-      scroller.workflow.call = () => null;
-      scroller.workflow = { call: this.callWorkflow };
+      scroller.workflow.call = (p?: ProcessSubject) => scroller.logger.log('[skip wf call]');
+      (<any>scroller.workflow.call).interrupted = true;
+      scroller.workflow = <ScrollerWorkflow>{ call: <Function>this.callWorkflow };
       this.interruptionCount++;
       scroller.logger.log(() =>
         `workflow had been interrupted by the ${process} process (${this.interruptionCount})`


### PR DESCRIPTION
This work relates to issue https://github.com/dhilt/ngx-ui-scroll/issues/112.

 - [x] adapter.reload method should carefully interrupt the ui-scroll workflow
 - [x] tests for double reload on fetch, on render and on adapter props change