### PR TITLE
Adapter.fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,4 +211,4 @@ The work has just begun. We have great plans and any participation is welcome! S
 
 __________
 
-2019 &copy; dhilt, [Hill30 Inc](http://www.hill30.com/)
+2020 &copy; dhilt, [Hill30 Inc](http://www.hill30.com/)

--- a/demo/app/samples/adapter/check-size.component.ts
+++ b/demo/app/samples/adapter/check-size.component.ts
@@ -128,7 +128,7 @@ autoscroll(index: number) {
     if (viewportElement.scrollTop === diff) {
       done();
     } else {
-      adapter.setScrollPosition(diff);
+      adapter.fix({ scrollPosition: diff });
       if (viewportElement.scrollTop === diff) {
         done();
       }
@@ -220,7 +220,7 @@ First visible item's index: {{datasource.adapter.firstVisible.$index}}
       if (viewportElement.scrollTop === diff) {
         done();
       } else {
-        adapter.setScrollPosition(diff);
+        adapter.fix({ scrollPosition: diff });
         if (viewportElement.scrollTop === diff) {
           done();
         }

--- a/demo/app/samples/test.component.ts
+++ b/demo/app/samples/test.component.ts
@@ -201,7 +201,7 @@ export class TestComponent {
         if (viewportElement.scrollTop === diff) {
           isLoadingSubscription.unsubscribe();
         } else {
-          adapter.setScrollPosition(diff);
+          adapter.fix({ scrollPosition: diff });
           if (viewportElement.scrollTop === diff) {
             isLoadingSubscription.unsubscribe();
           }

--- a/package-dist.json
+++ b/package-dist.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-ui-scroll",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "Infinite/virtual scroll for Angular",
   "main": "./bundles/ngx-ui-scroll.umd.js",
   "module": "./fesm5/ngx-ui-scroll.js",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "build-app": "ng build --prod --aot --source-map",
     "preinstall": "cd server && npm install",
     "postinstall": "npm run build-app",
-    "pack:install": "npm run build && npm pack ./dist && npm install ngx-ui-scroll-1.2.2.tgz --no-save",
+    "pack:install": "npm run build && npm pack ./dist && npm install ngx-ui-scroll-1.2.3.tgz --no-save",
     "pack:start": "npm run pack:install && npm start",
     "build": "node build.js",
     "publish:lib": "npm run build && npm publish ./dist",

--- a/src/component/classes/adapter.ts
+++ b/src/component/classes/adapter.ts
@@ -76,7 +76,7 @@ export class Adapter implements IAdapter {
     this.init$ = new BehaviorSubject<boolean>(false);
     this.context = new AdapterContext(this.init$);
 
-    ['reload', 'append', 'prepend', 'check', 'remove', 'clip', 'showLog', 'setScrollPosition']
+    ['reload', 'append', 'prepend', 'check', 'remove', 'clip', 'showLog', 'fix']
       .forEach(token => protectAdapterPublicMethod(this, token));
   }
 
@@ -148,26 +148,23 @@ export class Adapter implements IAdapter {
     this.context.logger.logForce();
   }
 
-  setScrollPosition(value: number) {
-    this.context.logger.log(() => `adapter: setScrollPosition(${value})`);
-    const position = Number(value);
-    const parsedValue = parseInt(<any>value, 10);
-    if (position !== parsedValue) {
-      this.context.logger.log(() =>
-        `can't set scroll position because ${value} is not an integer`);
-    } else {
-      this.context.setScrollPosition(value);
+  // undocumented
+  fix(params: any) {
+    this.context.logger.log(() => `adapter: fix(${JSON.stringify(params)})`);
+    if (!params || typeof params !== 'object') {
+      this.context.logger.log(() => `can't set params; argument must be a valid object`);
+      return;
     }
+    ['scrollPosition', 'minIndex', 'maxIndex'].forEach((token: string) => {
+      if (params.hasOwnProperty(token)) {
+        const value = Number(params[token]);
+        const parsedValue = parseInt(<any>params[token], 10);
+        if (value !== parsedValue) {
+          this.context.logger.log(() => `can't set ${token}; argument must be an integer`);
+        } else {
+          (<any>this.context.fix)[token](value);
+        }
+      }
+    });
   }
-
-  // setMinIndex(value: number) {
-  //   this.context.logger.log(() => `adapter: setMinIndex(${value})`);
-  //   const index = Number(value);
-  //   if (isNaN(index)) {
-  //     this.context.logger.log(() =>
-  //       `can't set minIndex because ${value} is not a number`);
-  //   } else {
-  //     this.scroller.buffer.minIndexUser = index;
-  //   }
-  // }
 }

--- a/src/component/classes/adapter.ts
+++ b/src/component/classes/adapter.ts
@@ -4,7 +4,7 @@ import { Scroller } from '../scroller';
 import { AdapterContext } from './adapterContext';
 import { protectAdapterPublicMethod } from '../utils/index';
 import {
-  Adapter as IAdapter, Process, ProcessSubject, ProcessStatus, ItemAdapter, ItemsPredicate, ClipOptions
+  Adapter as IAdapter, Process, ProcessSubject, ProcessStatus, ItemAdapter, ItemsPredicate, ClipOptions, FixOptions
 } from '../interfaces/index';
 
 export class Adapter implements IAdapter {
@@ -149,22 +149,12 @@ export class Adapter implements IAdapter {
   }
 
   // undocumented
-  fix(params: any) {
-    this.context.logger.log(() => `adapter: fix(${JSON.stringify(params)})`);
-    if (!params || typeof params !== 'object') {
-      this.context.logger.log(() => `can't set params; argument must be a valid object`);
-      return;
-    }
-    ['scrollPosition', 'minIndex', 'maxIndex'].forEach((token: string) => {
-      if (params.hasOwnProperty(token)) {
-        const value = Number(params[token]);
-        const parsedValue = parseInt(<any>params[token], 10);
-        if (value !== parsedValue) {
-          this.context.logger.log(() => `can't set ${token}; argument must be an integer`);
-        } else {
-          (<any>this.context.fix)[token](value);
-        }
-      }
+  fix(options: FixOptions) {
+    this.context.logger.log(() => `adapter: fix(${JSON.stringify(options)})`);
+    this.context.callWorkflow(<ProcessSubject>{
+      process: Process.fix,
+      status: ProcessStatus.start,
+      payload: options
     });
   }
 }

--- a/src/component/classes/adapterContext.ts
+++ b/src/component/classes/adapterContext.ts
@@ -5,10 +5,34 @@ import { Scroller } from '../scroller';
 import { Logger } from './logger';
 import { ItemAdapter, State as IState } from '../interfaces/index';
 
+interface Fix {
+  scrollPosition: (value: number) => void;
+  minIndex: (value: number) => void;
+  maxIndex: (value: number) => void;
+}
+
+function setFix(scroller: Scroller): Fix {
+  const { state, buffer, viewport, settings } = scroller;
+  return <Fix>{
+    scrollPosition: (value: number) => {
+      state.syntheticScroll.reset();
+      viewport.setPosition(value);
+    },
+    minIndex: (value: number) => {
+      settings.minIndex = value;
+      buffer.absMinIndex = value;
+    },
+    maxIndex: (value: number) => {
+      settings.maxIndex = value;
+      buffer.absMaxIndex = value;
+    }
+  };
+}
+
 export class AdapterContext {
   callWorkflow: Function;
   logger: Logger;
-  setScrollPosition: Function;
+  fix: Fix;
 
   private init$: BehaviorSubject<boolean>;
   private isInitialized: boolean;
@@ -122,10 +146,7 @@ export class AdapterContext {
     this.initializeProtected(state);
 
     // undocumented
-    this.setScrollPosition = (value: number) => {
-      state.syntheticScroll.reset();
-      scroller.viewport.setPosition(value);
-    };
+    this.fix = setFix(scroller);
 
     // run the subscriptions
     this.isInitialized = true;

--- a/src/component/classes/adapterContext.ts
+++ b/src/component/classes/adapterContext.ts
@@ -5,34 +5,9 @@ import { Scroller } from '../scroller';
 import { Logger } from './logger';
 import { ItemAdapter, State as IState } from '../interfaces/index';
 
-interface Fix {
-  scrollPosition: (value: number) => void;
-  minIndex: (value: number) => void;
-  maxIndex: (value: number) => void;
-}
-
-function setFix(scroller: Scroller): Fix {
-  const { state, buffer, viewport, settings } = scroller;
-  return <Fix>{
-    scrollPosition: (value: number) => {
-      state.syntheticScroll.reset();
-      viewport.setPosition(value);
-    },
-    minIndex: (value: number) => {
-      settings.minIndex = value;
-      buffer.absMinIndex = value;
-    },
-    maxIndex: (value: number) => {
-      settings.maxIndex = value;
-      buffer.absMaxIndex = value;
-    }
-  };
-}
-
 export class AdapterContext {
   callWorkflow: Function;
   logger: Logger;
-  fix: Fix;
 
   private init$: BehaviorSubject<boolean>;
   private isInitialized: boolean;
@@ -144,9 +119,6 @@ export class AdapterContext {
     this.getEOF = (): boolean => buffer.eof;
 
     this.initializeProtected(state);
-
-    // undocumented
-    this.fix = setFix(scroller);
 
     // run the subscriptions
     this.isInitialized = true;

--- a/src/component/interfaces/adapter.ts
+++ b/src/component/interfaces/adapter.ts
@@ -38,5 +38,5 @@ export interface Adapter {
   remove: (predicate: ItemsPredicate) => any;
   clip: (options?: ClipOptions) => any;
   showLog: () => any;
-  setScrollPosition: (value: number) => any;
+  fix: (params: any) => any; // undocumented
 }

--- a/src/component/interfaces/adapter.ts
+++ b/src/component/interfaces/adapter.ts
@@ -13,6 +13,12 @@ export interface ClipOptions {
   backwardOnly?: boolean;
 }
 
+export interface FixOptions {
+  scrollPosition?: number;
+  minIndex?: number;
+  maxIndex?: number;
+}
+
 export interface Adapter {
   init$: BehaviorSubject<boolean>;
   readonly version: string | null;
@@ -37,6 +43,6 @@ export interface Adapter {
   check: () => any;
   remove: (predicate: ItemsPredicate) => any;
   clip: (options?: ClipOptions) => any;
+  fix: (options: FixOptions) => any; // undocumented
   showLog: () => any;
-  fix: (params: any) => any; // undocumented
 }

--- a/src/component/interfaces/index.ts
+++ b/src/component/interfaces/index.ts
@@ -1,5 +1,5 @@
 import { Datasource, DatasourceGet } from './datasource';
-import { ItemAdapter, ItemsPredicate, ClipOptions, Adapter } from './adapter';
+import { ItemAdapter, ItemsPredicate, ClipOptions, FixOptions, Adapter } from './adapter';
 import { Settings, DevSettings } from './settings';
 import { Direction } from './direction';
 import { WindowScrollState, ScrollEventData, ScrollState, SyntheticScroll, WorkflowOptions, State } from './state';
@@ -25,6 +25,7 @@ export {
   State,
   ItemAdapter,
   ItemsPredicate,
+  FixOptions,
   ClipOptions,
   Adapter
 };

--- a/src/component/interfaces/process.ts
+++ b/src/component/interfaces/process.ts
@@ -7,6 +7,7 @@ export enum Process {
   check = 'adapter.check',
   remove = 'adapter.remove',
   userClip = 'adapter.clip',
+  fix = 'adapter.fix',
   start = 'start',
   preFetch = 'preFetch',
   fetch = 'fetch',

--- a/src/component/processes/fix.ts
+++ b/src/component/processes/fix.ts
@@ -7,28 +7,47 @@ interface IFix {
   maxIndex: (value: number) => void;
 }
 
-function setFix(scroller: Scroller): IFix {
-  const { state, buffer, viewport, settings } = scroller;
-  return <IFix>{
-    scrollPosition: (value: number) => {
-      state.syntheticScroll.reset();
-      viewport.setPosition(value);
-    },
-    minIndex: (value: number) => {
-      settings.minIndex = value;
-      buffer.absMinIndex = value;
-    },
-    maxIndex: (value: number) => {
-      settings.maxIndex = value;
-      buffer.absMaxIndex = value;
-    }
-  };
+enum FixParamToken {
+  scrollPosition = 'scrollPosition',
+  minIndex = 'minIndex',
+  maxIndex = 'maxIndex'
+}
+
+enum FixParamType {
+  integer = 'integer'
+}
+
+interface FixParam {
+  token: FixParamToken;
+  type: FixParamType;
+  call: Function;
+  value?: any;
 }
 
 export default class Fix {
 
+  static params: FixParam[] = [
+    {
+      token: FixParamToken.scrollPosition,
+      type: FixParamType.integer,
+      call: Fix.setScrollPosition
+    },
+    {
+      token: FixParamToken.minIndex,
+      type: FixParamType.integer,
+      call: Fix.setMinIndex
+    },
+    {
+      token: FixParamToken.maxIndex,
+      type: FixParamType.integer,
+      call: Fix.setMaxIndex
+    }
+  ];
+
   static run(scroller: Scroller, options: FixOptions) {
-    if (!Fix.checkOptions(options)) {
+    const params = Fix.checkOptions(scroller, options);
+
+    if (!params.length) {
       scroller.callWorkflow({
         process: Process.fix,
         status: ProcessStatus.error,
@@ -37,31 +56,58 @@ export default class Fix {
       return;
     }
 
-    const doFix = setFix(scroller);
-
-    ['scrollPosition', 'minIndex', 'maxIndex'].forEach((token: string) => {
-      if (options.hasOwnProperty(token)) {
-        const value = Number((<any>options)[token]);
-        const parsedValue = parseInt((<any>options)[token], 10);
-        if (value !== parsedValue) {
-          scroller.logger.log(() => `can't set ${token}; argument must be an integer`);
-        } else {
-          (<any>doFix)[token](value);
-        }
-      }
+    params.forEach((param: FixParam) => {
+      param.call(scroller, param.value);
     });
 
     scroller.callWorkflow({
       process: Process.fix,
-      status: ProcessStatus.next
+      status: ProcessStatus.done
     });
   }
 
-  static checkOptions(options: FixOptions) {
+  static setScrollPosition(scroller: Scroller, value: number) {
+    const { state, viewport } = scroller;
+    state.syntheticScroll.reset();
+    viewport.setPosition(value);
+  }
+
+  static setMinIndex(scroller: Scroller, value: number) {
+    const { buffer, settings } = scroller;
+    settings.minIndex = value;
+    buffer.absMinIndex = value;
+  }
+
+  static setMaxIndex(scroller: Scroller, value: number) {
+    const { buffer, settings } = scroller;
+    settings.maxIndex = value;
+    buffer.absMaxIndex = value;
+  }
+
+  static checkOptions(scroller: Scroller, options: FixOptions): FixParam[] {
     if (!options || typeof options !== 'object') {
-      return false;
+      return [];
     }
-    return true;
+    return Fix.params.reduce((acc: FixParam[], param: FixParam) => {
+      const { token, type } = param;
+      if (options.hasOwnProperty(token)) {
+        let value = (<any>options)[token];
+        let parsedValue = value;
+        let warning = '';
+        if (type === FixParamType.integer) {
+          value = Number(value);
+          parsedValue = parseInt(value, 10);
+          if (value !== parsedValue) {
+            warning = 'it must be an integer';
+          }
+        }
+        if (!warning) {
+          return [...acc, { ...param, value }];
+        }
+        scroller.logger.log(() => `can't set ${token}, ${warning}`);
+      }
+      return acc;
+    }, []);
   }
 
 }

--- a/src/component/processes/fix.ts
+++ b/src/component/processes/fix.ts
@@ -1,0 +1,67 @@
+import { Scroller } from '../scroller';
+import { Direction, ItemsPredicate, Process, ProcessStatus, FixOptions } from '../interfaces/index';
+
+interface IFix {
+  scrollPosition: (value: number) => void;
+  minIndex: (value: number) => void;
+  maxIndex: (value: number) => void;
+}
+
+function setFix(scroller: Scroller): IFix {
+  const { state, buffer, viewport, settings } = scroller;
+  return <IFix>{
+    scrollPosition: (value: number) => {
+      state.syntheticScroll.reset();
+      viewport.setPosition(value);
+    },
+    minIndex: (value: number) => {
+      settings.minIndex = value;
+      buffer.absMinIndex = value;
+    },
+    maxIndex: (value: number) => {
+      settings.maxIndex = value;
+      buffer.absMaxIndex = value;
+    }
+  };
+}
+
+export default class Fix {
+
+  static run(scroller: Scroller, options: FixOptions) {
+    if (!Fix.checkOptions(options)) {
+      scroller.callWorkflow({
+        process: Process.fix,
+        status: ProcessStatus.error,
+        payload: { error: `Wrong argument of the "Adapter.fix" method call` }
+      });
+      return;
+    }
+
+    const doFix = setFix(scroller);
+
+    ['scrollPosition', 'minIndex', 'maxIndex'].forEach((token: string) => {
+      if (options.hasOwnProperty(token)) {
+        const value = Number((<any>options)[token]);
+        const parsedValue = parseInt((<any>options)[token], 10);
+        if (value !== parsedValue) {
+          scroller.logger.log(() => `can't set ${token}; argument must be an integer`);
+        } else {
+          (<any>doFix)[token](value);
+        }
+      }
+    });
+
+    scroller.callWorkflow({
+      process: Process.fix,
+      status: ProcessStatus.next
+    });
+  }
+
+  static checkOptions(options: FixOptions) {
+    if (!options || typeof options !== 'object') {
+      return false;
+    }
+    return true;
+  }
+
+}

--- a/src/component/processes/index.ts
+++ b/src/component/processes/index.ts
@@ -5,6 +5,7 @@ import Append from './append';
 import Check from './check';
 import Remove from './remove';
 import UserClip from './userClip';
+import Fix from './fix';
 import Start from './start';
 import PreFetch from './preFetch';
 import Fetch from './fetch';
@@ -16,6 +17,6 @@ import Clip from './clip';
 import End from './end';
 
 export {
-  Init, Scroll, Reload, Append, Check, Remove, UserClip,
+  Init, Scroll, Reload, Append, Check, Remove, UserClip, Fix,
   Start, PreFetch, Fetch, PostFetch, Render, PreClip, Clip, Adjust, End
 };

--- a/src/component/utils/adapter.ts
+++ b/src/component/utils/adapter.ts
@@ -34,7 +34,7 @@ export const generateMockAdapter = (): IAdapter => (
     remove: () => null,
     clip: () => null,
     showLog: () => null,
-    setScrollPosition: () => null
+    fix: () => null // undocumented
   }
 );
 

--- a/src/component/workflow.ts
+++ b/src/component/workflow.ts
@@ -4,7 +4,7 @@ import { UiScrollComponent } from '../ui-scroll.component';
 import { Scroller } from './scroller';
 import { CallWorkflow, Process, ProcessStatus as Status, ProcessSubject, WorkflowError } from './interfaces/index';
 import {
-  Init, Scroll, Reload, Append, Check, Remove, UserClip,
+  Init, Scroll, Reload, Append, Check, Remove, UserClip, Fix,
   Start, PreFetch, Fetch, PostFetch, Render, PreClip, Clip, Adjust, End
 } from './processes/index';
 
@@ -179,6 +179,14 @@ export class Workflow {
         }
         if (status === Status.next) {
           run(Init)(process);
+        }
+        break;
+      case Process.fix:
+        if (status === Status.start) {
+          run(Fix)(payload);
+        }
+        if (status === Status.next) {
+          // run(Init)(process);
         }
         break;
       case Process.start:

--- a/src/component/workflow.ts
+++ b/src/component/workflow.ts
@@ -186,7 +186,7 @@ export class Workflow {
           run(Fix)(payload);
         }
         if (status === Status.next) {
-          // run(Init)(process);
+          run(Init)(process);
         }
         break;
       case Process.start:

--- a/src/ui-scroll.version.ts
+++ b/src/ui-scroll.version.ts
@@ -1,1 +1,1 @@
-export default '1.2.2';
+export default '1.2.3';

--- a/tests/miscellaneous/misc.ts
+++ b/tests/miscellaneous/misc.ts
@@ -121,7 +121,7 @@ export class Misc {
     if (native) {
       this.getScrollableElement()[this.horizontal ? 'scrollLeft' : 'scrollTop'] = value;
     } else {
-      this.datasource.adapter.setScrollPosition(value);
+      this.datasource.adapter.fix({ scrollPosition: value });
     }
   }
 


### PR DESCRIPTION
## Adapter.fix(options) &nbsp; <sup>available since v1.2.4</sup>

This new method is going to be undocumented for now. Currently the purpose of this method is to allow to change some internal parameters of the ui-scroll. The argument of `Adapter.fix(options)` method is an object implementing following interface:

```javascript
interface FixOptions {
  scrollPosition?: number;
  minIndex?: number;
  maxIndex?: number;
}
```

- Issue https://github.com/dhilt/ngx-ui-scroll/issues/114 is the start point for this PR.
- `Adapter.fix({ scrollPosition: value })` is being used in tests to change scroll position.
- Resetting the begin-of-file flag (BOF) is possible by  `Adapter.fix({ minIndex: -Infinity })` or any other appropriate value rather than `-Infinity` if new dataset border is known.
- The same for resetting end-of-file flag (EOF).
- Note that this technical method is not responsible for the ui-scroll workflow running, it just allow to fix some internal parameters, so running the workflow is a developer/app responsibility. Below are the examples that should help to catch the idea.
- The method is not documented and is not tested well, there is no guarantee that it will work properly and there is no guarantee that it will remain in future.

### One of the possible cases. Reduce and clip

The dataset boundaries are [-9..100] and we have [-9..20] items rendered with item 1 as the first visible. Having [-9..0] items within the invisible part of the viewport means the `scrollTop` value is `itemSize * 10` (not 0). And we want to cut off negative items with keeping item 1 at the topmost position. The solution:

```javascript
    this.datasource.adapter.fix({ minIndex: 1, scrollPosition: 0 });
    this.datasource.adapter.clip();
```

Here we set new minimal dataset border (`minIndex: 1`) and tell the ui-scroll to scroll to the very top of the viewport (`scrollPosition: 0`) for we don't want to get back-jump after clip. `clip` provides clipping all the items that indexes are less than new minimal index.

### Another case. Prepeding and virtualizing

The dataset boundaries are [1..100] and item 1 is the topmost visible item (`scrollTop` is 0). We want to set new boundaries [-99..100] and prepend first 10 items ([-9..0]) into the view. The solution

```javascript
const { adapter } = this.datasource;
const list = [];
for (let i = 0; i <100; i++) {
  const item = this.generateItemByIndex(--this.MIN); // this.MIN is the index of the left border
  this.data.unshift(item); // this.data is our dataset, so we pull [-99..0] new items into it
  if (i < 10) { // only [-9..0] items will be prepended immediately
    list.push(item);
  }
}
adapter.fix({ minIndex: -99 }); // tell the ui-scroll we have new left border
adapter.prepend(list); // prepend 10 items started with index -9
const sub = adapter.isLoading$.subscribe(isLoading => {
  if(!isLoading) {
    sub.unsubscribe();
    adapter.fix({ scrollPosition: 100 * 20 }); // adjust scrollTop for item 1 should be the first visible
  }
});
```

Self-destructing subscription is needed to make scroll position adjustment right after new 10 items are prepended and rendered in the view AND other 90 items are virtualized.