### PR TITLE
Make non-observable properties of the Adapter context configurable

### DIFF
--- a/src/component/classes/adapterContext.ts
+++ b/src/component/classes/adapterContext.ts
@@ -13,7 +13,8 @@ export class AdapterContext {
       prop => mock || prop.type !== AdapterPropType.Observable
     ).forEach(({ name, value }) =>
       Object.defineProperty(this, name, {
-        get: () => value
+        get: () => value,
+        configurable: true
       })
     );
     if (mock) {


### PR DESCRIPTION
Latest Adapter initialization changes cause "Cannot redefine property" TypeError in some cases. This PR provides a fix in accordance with [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Cant_redefine_property).

For issue #151.