### PR TITLE
Fix deep rxjs imports (Angular 9 support)

### DIFF
--- a/src/component/interfaces/state.ts
+++ b/src/component/interfaces/state.ts
@@ -1,4 +1,4 @@
-import { BehaviorSubject, Subject } from 'rxjs/index';
+import { BehaviorSubject, Subject } from 'rxjs';
 
 import { Direction, ItemAdapter } from './index';
 import { FetchModel } from '../classes/state/fetch';


### PR DESCRIPTION
Based on issue https://github.com/dhilt/ngx-ui-scroll/issues/148.