### PR TITLE
Patch Adapter methods resolver

### DIFF
--- a/package-dist.json
+++ b/package-dist.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-ui-scroll",
-  "version": "1.8.2",
+  "version": "1.8.3",
   "description": "Infinite/virtual scroll for Angular",
   "main": "./bundles/ngx-ui-scroll.umd.js",
   "module": "./fesm5/ngx-ui-scroll.js",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "deploy-app": "npm run build-app && firebase deploy",
     "preinstall": "cd server && npm install",
     "postinstall": "npm run build-app",
-    "pack:install": "npm run build && npm pack ./dist && npm install ngx-ui-scroll-1.8.2.tgz --no-save",
+    "pack:install": "npm run build && npm pack ./dist && npm install ngx-ui-scroll-1.8.3.tgz --no-save",
     "pack:start": "npm run pack:install && npm start",
     "build": "node build.js",
     "publish:lib": "npm run build && npm publish ./dist",

--- a/src/component/processes/clip.ts
+++ b/src/component/processes/clip.ts
@@ -47,6 +47,7 @@ export default class Clip {
       `, range: [${clipped[0]}..${clipped[clipped.length - 1]}]`
     ]);
     logger.stat('after clip');
+    clip.reset();
   }
 
 }

--- a/src/ui-scroll.version.ts
+++ b/src/ui-scroll.version.ts
@@ -1,1 +1,1 @@
-export default '1.8.2';
+export default '1.8.3';

--- a/tests/adapter.clip.spec.ts
+++ b/tests/adapter.clip.spec.ts
@@ -145,5 +145,14 @@ describe('Adapter Clip Spec', () => {
     })
   );
 
+  makeTest({
+    config: { datasourceSettings: { adapter: true } },
+    title: `should resolve immediately before scroller initialization`,
+    it: (misc: Misc) => async (done: Function) => {
+      await misc.adapter.clip();
+      done();
+    }
+  });
+
 });
 


### PR DESCRIPTION
This patch is a part of issue #213. 
Running `Adapter.clip` (and other Adapter methods) before the Scroller is initialized did not resolve the returning Promise immediately, and the following code did fail:

```ts
this.datasource = new Datasource(...);
this.datasource.adapter.clip().then(() => {
  // never happened before this patch
  console.log('It needs to be resolved immediately');
});
```

This PR fixes it.