### PR TITLE
Double clip case

### DIFF
--- a/package-dist.json
+++ b/package-dist.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-ui-scroll",
-  "version": "1.8.4",
+  "version": "1.8.5",
   "description": "Infinite/virtual scroll for Angular",
   "main": "./bundles/ngx-ui-scroll.umd.js",
   "module": "./fesm5/ngx-ui-scroll.js",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "deploy-app": "npm run build-app && firebase deploy",
     "preinstall": "cd server && npm install",
     "postinstall": "npm run build-app",
-    "pack:install": "npm run build && npm pack ./dist && npm install ngx-ui-scroll-1.8.4.tgz --no-save",
+    "pack:install": "npm run build && npm pack ./dist && npm install ngx-ui-scroll-1.8.5.tgz --no-save",
     "pack:start": "npm run pack:install && npm start",
     "build": "node build.js",
     "publish:lib": "npm run build && npm publish ./dist",

--- a/src/component/classes/state/clip.ts
+++ b/src/component/classes/state/clip.ts
@@ -19,9 +19,13 @@ export class ClipModel {
     this.reset();
   }
 
-  reset() {
+  reset(isForce?: boolean) {
     this.doClip = false;
-    this.forceReset();
+    if (!isForce) {
+      this.forceReset();
+    } else {
+      this.simulate = false;
+    }
   }
 
   forceReset() {

--- a/src/component/processes/clip.ts
+++ b/src/component/processes/clip.ts
@@ -46,12 +46,14 @@ export default class Clip {
       buffer.items = buffer.items.filter(({ toRemove }) => !toRemove);
     }
 
-    logger.log(() => [
-      `clipped ${itemsToRemove.length} items` +
-      (size.backward ? `, +${size.backward} fwd px` : '') +
-      (size.forward ? `, +${size.forward} bwd px` : '') +
-      `, range: [${itemsToRemove[0].$index}..${itemsToRemove[itemsToRemove.length - 1].$index}]`
-    ]);
+    logger.log(() => itemsToRemove.length
+      ? [
+        `clipped ${itemsToRemove.length} items` +
+        (size.backward ? `, +${size.backward} fwd px` : '') +
+        (size.forward ? `, +${size.forward} bwd px` : '') +
+        `, range: [${itemsToRemove[0].$index}..${itemsToRemove[itemsToRemove.length - 1].$index}]`
+      ]
+      : 'clipped 0 items');
 
     viewport.scrollPosition = position;
 

--- a/src/component/processes/start.ts
+++ b/src/component/processes/start.ts
@@ -14,8 +14,8 @@ export default class Start {
     if (!fetch.simulate) {
       fetch.reset();
     }
-    if (!clip.simulate && !clip.force) {
-      clip.reset();
+    if (!clip.simulate) {
+      clip.reset(clip.force);
     }
     render.reset();
 

--- a/src/ui-scroll.version.ts
+++ b/src/ui-scroll.version.ts
@@ -1,1 +1,1 @@
-export default '1.8.4';
+export default '1.8.5';

--- a/tests/bug.spec.ts
+++ b/tests/bug.spec.ts
@@ -221,4 +221,24 @@ describe('Bug Spec', () => {
     });
   });
 
+  describe('double clip', () =>
+    makeTest({
+      title: 'should clip once',
+      config: {
+        datasourceName: 'default',
+        datasourceSettings: { adapter: true, bufferSize: 50 }
+      },
+      it: (misc: Misc) => async (done: Function) => {
+        const { clip } = misc.scroller.state;
+        await misc.relaxNext();
+        expect(clip.callCount).toEqual(0);
+        await misc.adapter.clip();
+        expect(clip.callCount).toEqual(1);
+        await misc.adapter.clip();
+        expect(clip.callCount).toEqual(1);
+        done();
+      }
+    })
+  );
+
 });


### PR DESCRIPTION
Running two clip processes in sequence must lead to only 1 clip. The following (new) test states this requirement:

https://github.com/dhilt/ngx-ui-scroll/blob/7b7a37c124a0658c590a2b28dfa6a0f56aeea2d3/tests/bug.spec.ts#L234-L238

This PR provides necessary changes. It also relates to issue #213.