### PR TITLE
Adapter.relax chaining

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,10 +20,6 @@ debug.log
 
 # IDE - VSCode
 .vscode/*
-!.vscode/settings.json
-!.vscode/tasks.json
-!.vscode/launch.json
-!.vscode/extensions.json
 
 # misc
 /.sass-cache

--- a/README.md
+++ b/README.md
@@ -186,14 +186,15 @@ Below is the list of invocable methods of the Adapter API with description and l
 
 Along with the documented API there are some undocumented features that can be treated as experimental. They are not tested enough and might change over time. Some of them can be found on the [experimental tab](https://dhilt.github.io/ngx-ui-scroll/#/experimental) of the demo app.
 
-All of the Adapter methods return Promise resolving at the moment when the scroller terminates its internal processes triggered by the invocation of the Adapter method. It might be quite important to run some logic after the Adapter finished its job:
+All of the Adapter methods return Promise resolving at the moment when the scroller terminates its internal processes triggered by the invocation of the Adapter method. It might be quite important to run some logic after the Adapter finished its job. Also, it is recommended to protect the first Adapter call by the [relax method](https://dhilt.github.io/ngx-ui-scroll/#/experimental#adapter-relax). Below is an example of how an explicit sequence of the Adapter methods can be implemented:
 
 ```js
 const { adapter } = this.datasource;
 const predicate = ({ $index }) => $index === indexToReplace;
+await adapter.relax();
 await adapter.remove(predicate);
-await adapter.insert({ items: [itemToReplace], after: predicate });
-this.notify('Replacement done');
+await adapter.insert({ items: [itemToReplace], before: predicate });
+console.log('Replacement done');
 ```
 
 For more information, see [Adapter demo page](https://dhilt.github.io/ngx-ui-scroll/#/adapter).

--- a/demo/app/samples/adapter/adapter-return-value.component.html
+++ b/demo/app/samples/adapter/adapter-return-value.component.html
@@ -20,7 +20,7 @@
       for example, if some method is invoked with wrong arguments, no error will be thrown,
       but we'll get <em>success:&nbsp;false</em> in the result;
       <br>
-      - <em>error</em>: contains error message in case <em>success</em> is <em>false</em>;
+      - <em>details</em>: contains error message in case <em>success</em> is <em>false</em>;
       <br>
       - <em>immediate</em>: specifies whether the <em>Adapter</em> method completed immediately or not;
       for example, if <em>Adapter.remove</em> won't remove any items, then it will be

--- a/demo/app/samples/adapter/adapter-return-value.component.html
+++ b/demo/app/samples/adapter/adapter-return-value.component.html
@@ -31,11 +31,12 @@
 
     <p>
       Note, <em>immediate:&nbsp;false</em> does not necessarily mean that the <em>Adapter</em> method
-      worked asynchronously. But, in most cases we'll have async processes,
-      so it is highly recommended to pay special attention to logic that is going to be run
-      after the <em>Adapter</em> method is invoked. Generally such logic needs to be
-      postponed by waiting for the promisified result of the <em>Adapter</em> method invocation.
+      worked asynchronously. But in any case, if there is any logic that needs to be run after
+      the Adapter method completes its job, it is highly recommended
+      to implement an explicit sequence like this:
     </p>
+
+    <pre>{{explicitSequenceSample}}</pre>
 
   </div>
 

--- a/demo/app/samples/adapter/adapter-return-value.component.ts
+++ b/demo/app/samples/adapter/adapter-return-value.component.ts
@@ -2,8 +2,6 @@ import { Component } from '@angular/core';
 
 import { DemoContext } from '../../shared/interfaces';
 
-import { Datasource } from '../../../../public_api'; // from 'ngx-ui-scroll';
-
 @Component({
   selector: 'app-demo-adapter-return-value',
   templateUrl: './adapter-return-value.component.html'
@@ -27,4 +25,9 @@ export class DemoAdapterReturnValueComponent {
   if (immediate) {
     console.log('No items were removed');
   }`;
+
+  explicitSequenceSample = `
+  await adapter.append({ items });
+  scrollToBottom(); // will not scroll without "await"
+  `;
 }

--- a/demo/app/samples/adapter/adapter-return-value.component.ts
+++ b/demo/app/samples/adapter/adapter-return-value.component.ts
@@ -17,7 +17,7 @@ export class DemoAdapterReturnValueComponent {
   returnValueType = `  Promise<{
     success: boolean,
     immediate: boolean,
-    error?: string
+    details: string | null
   }>`;
 
   returnValueSample = `

--- a/demo/app/samples/experimental/adapter-fix-position.component.html
+++ b/demo/app/samples/experimental/adapter-fix-position.component.html
@@ -8,7 +8,7 @@
 
   <div description>
     <p>
-      The first option of <em>Adapter.fix</em> method is <em>scrollPosition</em>.
+      The first option of the <em>Adapter.fix</em> method is <em>scrollPosition</em>.
       It allows to change the position of the viewport's scrollbar programmatically.
       It is used in the lib tests.
     </p>

--- a/demo/app/samples/experimental/adapter-fix-updater.component.html
+++ b/demo/app/samples/experimental/adapter-fix-updater.component.html
@@ -13,7 +13,7 @@
 
   <div description>
     <p>
-      <em>Adapter.fix</em> method could be invoked with <em>updater</em> option
+      The <em>Adapter.fix</em> method could be invoked with <em>updater</em> option
       which is a function that is applied to each element in current <em>uiScroll</em> buffer list
       and allows to update buffered items on the fly.
       The argument of the <em>updater</em> function is an object of special <em>ItemAdapter</em> type

--- a/demo/app/samples/experimental/adapter-relax.component.html
+++ b/demo/app/samples/experimental/adapter-relax.component.html
@@ -7,32 +7,47 @@
 
   <div description>
     <p>
+      If we need to run any logic that should not interfere with the Scroller internal processes,
+      it should be protected by the "relax" promise:
+    </p>
+    <pre>{{relaxSample}}</pre>
+    <p>
+      In this demo we simulate items replacement
+      by performing a sequence of 2 <em>Adapter</em> methods: remove and insert.
+      A few existed items (5, 6, 7) are being replaced with a new one (5*).
+      Removing is an asynchronous operation, and we can't perform
+      "insert" before "remove" is done (it will produce an error).
+      Thus, both operations must be run in sequence.
+      Also, we should be wary of any async processes
+      before running the Adapter methods chain.
+      So the algorithm for this demo can be written be as follows: 
+    </p>
+    <ul>
+      <li>wait for scroller stops</li>
+      <li>run remove</li>
+      <li>wait for remove is done</li>
+      <li>run insert</li>
+    </ul>
+    <p>
       The purpose of the <em>Adapter.relax</em> method is to make sure that the <em>uiScroll</em> relaxes
-      and there are no internal processes working at the moment we need to run some logic.
-      Basically, it may be treated as a shortcut for the following approach,
-      which is presented on "Is&nbsp;loading" tab:
+      and there are no pending internal tasks running on the Scroller's end.
+      The first tab "Relax" demonstrates how the desired sequence can be implemented with
+      the <em>Adapter.relax</em> method.
+      This method returns a promise which becomes resolved when the Scroller stops.
+      Basically, this may be treated as a shortcut for the following approach,
+      which is presented on the "Is&nbsp;loading" tab:
     </p>
     <pre>{{isLoadingSample}}</pre>
     <p>
-      The <em>Adapter.relax</em> method accepts 1 optional argument, it is a callback
-      that allow to run necessary logic right before resolving "relax" promise.
-      This might be helpful if we don't want to wait until the end of the call stack.
-      The "Relax cb" tab shows the difference between "await" and "callback" approaches.
+      All the tabs are equivalent. The third tab "Callback" uses a callback signature of
+      the <em>Adapter.relax</em> method. The method accepts callback as an optional argument,
+      and this allows to run necessary logic right before resolving the "relax" promise.
+      This might be helpful if we don't want to wait until the end of current call stack.
     </p>
     <p>
-      This sample is quite artificial, because for 2 manual operations (remove and insert)
-      the second one can be done safely by using <a href="#/adapter#return-value">Return value</a> API,
-      which is a part of each <em>Adapter</em> method.
-      This approach is demonstrated on the last tab "Return".
+      At last, we may use <a href="#/adapter#return-value">Return value API</a>
+      (which is a part of each <em>Adapter</em> method)
+      and get rid of the second "relax". This approach is demonstrated on the last tab "Return".
     </p>
-    <p>
-      But the point is that the first manual operation also might require safe call.
-      If we have a chance that there are some pending processes
-      at the moment we are going to run the <em>Adapter</em> method,
-      then we should wait until these processes are done.
-      The "Is loading" approach is about it. But having the "Relax" shortcut
-      we may make our life easier.
-    </p>
-    <pre>{{relaxSample}}</pre>
   </div>
 </app-demo>

--- a/demo/app/samples/experimental/adapter-relax.component.ts
+++ b/demo/app/samples/experimental/adapter-relax.component.ts
@@ -29,9 +29,9 @@ export class DemoAdapterRelaxComponent {
   sources: DemoSources = [{
     active: true,
     name: 'Relax',
-    text: `
-async doReplace() {
+    text: `async doReplace() {
   const { adapter } = this.datasource;
+  await adapter.relax();
   adapter.remove(({ $index }) =>
     $index > 4 && $index < 8
   );
@@ -44,38 +44,46 @@ async doReplace() {
 `
 }, {
     name: 'Is loading',
-    text: `
-doReplace() {
+    text: `relax(cb: Function) {
   const { adapter } = this.datasource;
-  adapter.remove(({ $index }) =>
-    $index > 4 && $index < 8
-  );
-  const insert = () => adapter.insert({
-    items: [{ id: '5*', text: 'item #5 *' }],
-    after: ({ $index }) => $index === 4 }
-  );
   if (!adapter.isLoading) {
-    insert();
+    cb();
   } else {
     adapter.isLoading$
       .pipe(filter(isLoading => !isLoading), take(1))
-      .subscribe(() => insert());
+      .subscribe(() => cb());
   }
+}
+
+doReplace() {
+  const { adapter } = this.datasource;
+  this.relax(() =>
+    adapter.remove(({ $index }) =>
+      $index > 4 && $index < 8
+    )
+  );
+  this.relax(() =>
+    adapter.insert({
+      items: [{ id: '5*', text: 'item #5 *' }],
+      after: ({ $index }) => $index === 4
+    })
+  );
 }
 `
 }, {
-    name: 'Relax cb',
-    text: `
-doReplace() {
+    name: 'Callback',
+    text: `doReplace() {
   const { adapter } = this.datasource;
-  adapter.remove(({ $index }) =>
-    $index > 4 && $index < 8
+  adapter.relax(() =>
+    adapter.remove(({ $index }) =>
+      $index > 4 && $index < 8
+    )
   );
   adapter.relax(() =>
     adapter.insert({
       items: [{ id: '5*', text: 'item #5 *' }],
-      after: ({ $index }) => $index === 4 }
-    );
+      after: ({ $index }) => $index === 4
+    })
   );
 }
 `
@@ -83,13 +91,14 @@ doReplace() {
     name: 'Return',
     text: `async doReplace() {
   const { adapter } = this.datasource;
+  await adapter.relax();
   await adapter.remove(({ $index }) =>
     $index > 4 && $index < 8
   );
   adapter.insert({
     items: [{ id: '5*', text: 'item #5 *' }],
-    after: ({ $index }) => $index === 4 }
-  );
+    after: ({ $index }) => $index === 4
+  });
 }
 `
 }];
@@ -110,6 +119,7 @@ doReplace() {
   async doReplace() {
     const { adapter } = this.datasource;
     const newItem = { id: '5*', text: 'item #5 *' };
+    await adapter.relax();
     adapter.remove(({ $index }) => $index > 4 && $index < 8);
     await adapter.relax();
     adapter.insert({ items: [newItem], after: ({ $index }) => $index === 4 });

--- a/demo/app/samples/experimental/viewportElement-setting.component.html
+++ b/demo/app/samples/experimental/viewportElement-setting.component.html
@@ -7,7 +7,7 @@
 
   <div description>
     <p>
-      As it follows the doc, the viewport is a scrollable area with a finite height.
+      As it follows from the doc, the viewport is a scrollable area with a finite height.
       By default, the nearest ancestor of the <em>*uiScroll</em> container is treated as the Viewport.
       With the <em>viewportElement</em> setting we may change the default behavior
       and make another html element to be our Viewport.

--- a/package-dist.json
+++ b/package-dist.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-ui-scroll",
-  "version": "1.8.5",
+  "version": "1.9.0-rc",
   "description": "Infinite/virtual scroll for Angular",
   "main": "./bundles/ngx-ui-scroll.umd.js",
   "module": "./fesm5/ngx-ui-scroll.js",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "deploy-app": "npm run build-app && firebase deploy",
     "preinstall": "cd server && npm install",
     "postinstall": "npm run build-app",
-    "pack:install": "npm run build && npm pack ./dist && npm install ngx-ui-scroll-1.8.5.tgz --no-save",
+    "pack:install": "npm run build && npm pack ./dist && npm install ngx-ui-scroll-1.9.0-rc.tgz --no-save",
     "pack:start": "npm run pack:install && npm start",
     "build": "node build.js",
     "publish:lib": "npm run build && npm publish ./dist",

--- a/src/component/classes/adapter.ts
+++ b/src/component/classes/adapter.ts
@@ -56,7 +56,6 @@ export class Adapter implements IAdapter {
   get workflow(): ScrollerWorkflow {
     return this.getWorkflow();
   }
-
   get reloadCount(): number {
     return this.reloadCounter;
   }
@@ -213,7 +212,7 @@ export class Adapter implements IAdapter {
     this.logger = logger;
 
     // self-pending
-    if (onAdapterRun$) {
+    if (onAdapterRun$) { // passed on the very first init only
       if (!this.relax$) {
         this.relax$ = new Subject<AdapterMethodRelax>();
       }
@@ -223,7 +222,7 @@ export class Adapter implements IAdapter {
         if (status === ProcessStatus.start) {
           relax$.next(false);
           isLoadingSub = this.isLoading$
-            .pipe(filter(isLoading => !isLoading), take(1))
+            .pipe(filter(isLoading => !isLoading), take(1), takeUntil(dispose$))
             .subscribe(() => relax$.next({ success: true, immediate: false }));
         }
         if (status === ProcessStatus.done || status === ProcessStatus.error) {
@@ -244,6 +243,7 @@ export class Adapter implements IAdapter {
     if (this.relax$) {
       this.relax$.complete();
     }
+    Object.values(this.source).forEach(observable => observable.complete());
    }
 
   reset(options?: IDatasourceOptional): any {

--- a/src/component/classes/logger.ts
+++ b/src/component/classes/logger.ts
@@ -143,14 +143,13 @@ export class Logger {
     }
   }
 
-  logAdapterMethod = (methodName: string, methodArg?: any, methodSecondArg?: any) => {
+  logAdapterMethod = (methodName: string, args?: any, add?: string) => {
     if (!this.debug) {
       return;
     }
-    const params = [
-      ...(methodArg ? [methodArg] : []),
-      ...(methodSecondArg ? [methodSecondArg] : [])
-    ]
+    const params = (
+      args === void 0 ? [] : (Array.isArray(args) ? args : [args])
+    )
       .map((arg: any) => {
         if (typeof arg === 'function') {
           return 'func';
@@ -162,7 +161,7 @@ export class Logger {
         return '{ ' + Object.keys(arg).join(', ') + ' }';
       })
       .join(', ');
-    this.log(`adapter: ${methodName}(${params || ''})`);
+    this.log(`adapter: ${methodName}(${params || ''})${add || ''}`);
   }
 
   log(...args: any[]) {

--- a/src/component/interfaces/adapter.ts
+++ b/src/component/interfaces/adapter.ts
@@ -59,13 +59,12 @@ export interface AdapterFixOptions {
   scrollToItemOpt?: boolean | ScrollIntoViewOptions;
 }
 
-interface MethodResultStatus {
+export interface AdapterMethodResult {
   success: boolean;
   immediate: boolean;
   details: string | null;
 }
-export type MethodResult = Promise<MethodResultStatus>;
-export type AdapterMethodRelax = boolean | MethodResultStatus;
+type MethodResult = Promise<AdapterMethodResult>;
 
 export interface IAdapter {
   readonly id: number;

--- a/src/component/interfaces/adapter.ts
+++ b/src/component/interfaces/adapter.ts
@@ -1,6 +1,5 @@
 import { BehaviorSubject, Subject } from 'rxjs';
 
-import { IValidator, ValidatedValue } from './validation';
 import { IDatasourceOptional } from './datasource';
 
 export enum AdapterPropType {
@@ -63,9 +62,9 @@ export interface AdapterFixOptions {
 interface MethodResultStatus {
   success: boolean;
   immediate: boolean;
-  error?: string;
+  details: string | null;
 }
-type MethodResult = Promise<MethodResultStatus>;
+export type MethodResult = Promise<MethodResultStatus>;
 export type AdapterMethodRelax = boolean | MethodResultStatus;
 
 export interface IAdapter {

--- a/src/component/interfaces/index.ts
+++ b/src/component/interfaces/index.ts
@@ -19,8 +19,7 @@ import {
   AdapterClipOptions,
   AdapterInsertOptions,
   AdapterFixOptions,
-  MethodResult,
-  AdapterMethodRelax,
+  AdapterMethodResult,
   IAdapter,
 } from './adapter';
 import { Settings, DevSettings } from './settings';
@@ -51,8 +50,7 @@ export {
   AdapterPropType,
   IAdapterProp,
   ItemAdapter,
-  MethodResult,
-  AdapterMethodRelax,
+  AdapterMethodResult,
   IAdapter,
   ItemsPredicate,
   ItemsLooper,

--- a/src/component/interfaces/index.ts
+++ b/src/component/interfaces/index.ts
@@ -19,6 +19,7 @@ import {
   AdapterClipOptions,
   AdapterInsertOptions,
   AdapterFixOptions,
+  MethodResult,
   AdapterMethodRelax,
   IAdapter,
 } from './adapter';
@@ -50,6 +51,7 @@ export {
   AdapterPropType,
   IAdapterProp,
   ItemAdapter,
+  MethodResult,
   AdapterMethodRelax,
   IAdapter,
   ItemsPredicate,

--- a/src/ui-scroll.version.ts
+++ b/src/ui-scroll.version.ts
@@ -1,1 +1,1 @@
-export default '1.8.5';
+export default '1.9.0-rc';

--- a/tests/adapter.clip.spec.ts
+++ b/tests/adapter.clip.spec.ts
@@ -10,8 +10,8 @@ const configList: TestBedConfig[] = [{
   datasourceSettings: { startIndex: -158, bufferSize: 11, padding: 0.68, itemSize: 20 },
   templateSettings: { viewportHeight: 77, itemHeight: 20 }
 }, {
-  datasourceSettings: { startIndex: 1, bufferSize: 5, padding: 1, horizontal: true, itemSize: 90 },
-  templateSettings: { viewportWidth: 450, itemWidth: 90, horizontal: true }
+  datasourceSettings: { startIndex: 1, bufferSize: 5, padding: 1, horizontal: true, itemSize: 100 },
+  templateSettings: { viewportWidth: 450, itemWidth: 100, horizontal: true }
 }, {
   datasourceSettings: { startIndex: -274, bufferSize: 3, padding: 1.22, horizontal: true, itemSize: 75 },
   templateSettings: { viewportWidth: 320, itemWidth: 75, horizontal: true }

--- a/tests/adapter.prepend.spec.ts
+++ b/tests/adapter.prepend.spec.ts
@@ -11,8 +11,8 @@ const configList: TestBedConfig[] = [{
   datasourceSettings: { startIndex: -15, bufferSize: 12, padding: 0.98, itemSize: 20 },
   templateSettings: { viewportHeight: 66, itemHeight: 20 }
 }, {
-  datasourceSettings: { startIndex: 1, bufferSize: 5, padding: 1, horizontal: true, itemSize: 90 },
-  templateSettings: { viewportWidth: 450, itemWidth: 90, horizontal: true }
+  datasourceSettings: { startIndex: 1, bufferSize: 5, padding: 1, horizontal: true, itemSize: 100 },
+  templateSettings: { viewportWidth: 450, itemWidth: 100, horizontal: true }
 }, {
   datasourceSettings: { startIndex: -74, bufferSize: 4, padding: 0.72, horizontal: true, itemSize: 75 },
   templateSettings: { viewportWidth: 300, itemWidth: 75, horizontal: true }

--- a/tests/adapter.reload.spec.ts
+++ b/tests/adapter.reload.spec.ts
@@ -121,8 +121,8 @@ const checkExpectation = (config: TestBedConfig, misc: Misc) => {
   const itemsPerViewport = Math.ceil(viewport.getSize() / buffer.averageSize);
 
   expect(firstItem ? firstItem.$index : null).toEqual(firstIndex);
-  expect(misc.getElementText(firstIndex)).toEqual(`${firstIndex} : item #${firstIndex}`);
-  expect(misc.getElementText(nextIndex)).toEqual(`${nextIndex} : item #${nextIndex}`);
+  expect(misc.checkElementContentByIndex(firstIndex)).toEqual(true);
+  expect(misc.checkElementContentByIndex(nextIndex)).toEqual(true);
   expect(firstVisible.$index).toEqual(startIndex);
   expect(lastVisible.$index).toEqual(startIndex + itemsPerViewport - 1);
   expect(misc.workflow.interruptionCount).toEqual(config.custom.interruptionCount);

--- a/tests/adapter.reload.spec.ts
+++ b/tests/adapter.reload.spec.ts
@@ -1,7 +1,7 @@
 import { makeTest, TestBedConfig } from './scaffolding/runner';
 import { Misc } from './miscellaneous/misc';
 
-const customDefault = { startIndex: null, scrollCount: 0, preLoad: false, interruptionCount: 0 };
+const customDefault = { startIndex: null, scrollCount: 0, preLoad: false, reloadCount: 1, interruptionCount: 0 };
 
 const configList: TestBedConfig[] = [{
   datasourceSettings: { startIndex: 100, bufferSize: 5, padding: 0.2, adapter: true },
@@ -58,6 +58,7 @@ const doubleReloadConfigList: TestBedConfig[] = configList.map((config, i) => ({
   ...config,
   custom: {
     ...config.custom,
+    reloadCount: 2,
     interruptionCount: 1,
     startIndex: [10, 365, -14][i]
   }
@@ -75,6 +76,7 @@ doubleReloadConfigList.push({
   },
   templateSettings: { viewportHeight: 600 },
   custom: {
+    reloadCount: 2,
     interruptionCount: 1,
     startIndex: 999
   }
@@ -84,6 +86,7 @@ const onRenderReloadConfigList = configList.map((config, i) => ({
   ...config,
   custom: {
     ...config.custom,
+    reloadCount: 2,
     interruptionCount: 1,
     startIndex: [500, -25, null][i]
   }
@@ -126,6 +129,7 @@ const checkExpectation = (config: TestBedConfig, misc: Misc) => {
   expect(firstVisible.$index).toEqual(startIndex);
   expect(lastVisible.$index).toEqual(startIndex + itemsPerViewport - 1);
   expect(misc.workflow.interruptionCount).toEqual(config.custom.interruptionCount);
+  expect(misc.scroller.adapter.reloadCount).toEqual(config.custom.reloadCount);
 };
 
 const accessFirstLastVisibleItems = (misc: Misc) => {

--- a/tests/bug.spec.ts
+++ b/tests/bug.spec.ts
@@ -241,34 +241,4 @@ describe('Bug Spec', () => {
     })
   );
 
-  describe('concurrent sequences of the Adapter calls', () => {
-    const START = 100;
-    const COUNT = 25;
-    const doAppendAndScroll = async (_misc: Misc, index: number): Promise<any> => {
-      const { adapter } = _misc;
-      await adapter.relax();
-      await adapter.append(generateItem(index));
-      await adapter.fix({ scrollPosition: Infinity });
-    };
-
-    makeTest({
-      title: 'should run a sequence within sequence',
-      config: {
-        datasourceName: 'limited-1-100-no-delay',
-        datasourceSettings: { adapter: true, startIndex: START }
-      },
-      it: (misc: Misc) => async (done: Function) => {
-        await misc.relaxNext();
-        const scrollPosition = misc.getScrollPosition();
-        for (let i = 0; i < COUNT; i++) {
-          doAppendAndScroll(misc, START + i + 1);
-        }
-        await misc.adapter.relax();
-        const newScrollPosition = scrollPosition + misc.getItemSize() * COUNT;
-        expect(misc.getScrollPosition()).toEqual(newScrollPosition);
-        done();
-      }
-    });
-  });
-
 });

--- a/tests/initial-load.spec.ts
+++ b/tests/initial-load.spec.ts
@@ -12,8 +12,8 @@ const fixedItemSizeConfigList: TestBedConfig[] = [{
   datasourceSettings: { startIndex: -99, padding: 0.3, itemSize: 25 },
   templateSettings: { viewportHeight: 200, itemHeight: 25 }
 }, {
-  datasourceSettings: { startIndex: -77, padding: 0.62, itemSize: 90, horizontal: true },
-  templateSettings: { viewportWidth: 450, itemWidth: 90, horizontal: true }
+  datasourceSettings: { startIndex: -77, padding: 0.62, itemSize: 100, horizontal: true },
+  templateSettings: { viewportWidth: 450, itemWidth: 100, horizontal: true }
 }, {
   datasourceSettings: { startIndex: 1, padding: 0.5, itemSize: 20, windowViewport: true },
   templateSettings: { noViewportClass: true, viewportHeight: 0, itemHeight: 20 }
@@ -23,8 +23,8 @@ const fixedItemSizeAndBigBufferSizeConfigList: TestBedConfig[] = [{
   datasourceSettings: { startIndex: 100, padding: 0.1, itemSize: 20, bufferSize: 20 },
   templateSettings: { viewportHeight: 100, itemHeight: 20 }
 }, {
-  datasourceSettings: { startIndex: -50, padding: 0.1, itemSize: 90, bufferSize: 10, horizontal: true },
-  templateSettings: { viewportWidth: 200, itemWidth: 90, horizontal: true }
+  datasourceSettings: { startIndex: -50, padding: 0.1, itemSize: 100, bufferSize: 10, horizontal: true },
+  templateSettings: { viewportWidth: 200, itemWidth: 100, horizontal: true }
 }];
 
 const tunedItemSizeConfigList: TestBedConfig[] = [{
@@ -35,7 +35,7 @@ const tunedItemSizeConfigList: TestBedConfig[] = [{
   templateSettings: { viewportHeight: 120, itemHeight: 20 }
 }, {
   datasourceSettings: { startIndex: -77, padding: 0.82, itemSize: 200, horizontal: true },
-  templateSettings: { viewportWidth: 450, itemWidth: 90, horizontal: true }
+  templateSettings: { viewportWidth: 450, itemWidth: 100, horizontal: true }
 }, {
   datasourceSettings: { startIndex: -47, padding: 0.3, itemSize: 60, windowViewport: true },
   templateSettings: { noViewportClass: true, viewportHeight: 0, itemHeight: 40 }

--- a/tests/min-max-indexes.spec.ts
+++ b/tests/min-max-indexes.spec.ts
@@ -11,8 +11,8 @@ const configList: TestBedConfig[] = [{
   datasourceSettings: { startIndex: 174, padding: 0.7, itemSize: 25, minIndex: 169, maxIndex: 230 },
   templateSettings: { viewportHeight: 50, itemHeight: 25 }
 }, {
-  datasourceSettings: { startIndex: 33, padding: 0.62, itemSize: 90, minIndex: 20, maxIndex: 230, horizontal: true },
-  templateSettings: { viewportWidth: 450, itemWidth: 90, horizontal: true }
+  datasourceSettings: { startIndex: 33, padding: 0.62, itemSize: 100, minIndex: 20, maxIndex: 230, horizontal: true },
+  templateSettings: { viewportWidth: 450, itemWidth: 100, horizontal: true }
 }, {
   datasourceSettings: {
     startIndex: 1,

--- a/tests/miscellaneous/misc.ts
+++ b/tests/miscellaneous/misc.ts
@@ -51,7 +51,7 @@ export class Misc {
   window: boolean;
 
   itemHeight = 20;
-  itemWidth = 90;
+  itemWidth = 100;
   shared: any = {};
 
   constructor(fixture: ComponentFixture<TestComponentInterface>) {
@@ -100,11 +100,11 @@ export class Misc {
   }
 
   checkElementContentByIndex(index: number | null): boolean {
-    return index !== null && this.getElementText(index) === index + ' : ' + generateItem(index).text;
+    return index !== null && this.getElementText(index) === index + ': ' + generateItem(index).text;
   }
 
   checkElementContent(index: number, id: number): boolean {
-    return this.getElementText(index) === index + ' : ' + generateItem(id).text;
+    return this.getElementText(index) === index + ': ' + generateItem(id).text;
   }
 
   checkElementId(element: HTMLElement, index: number): boolean {

--- a/tests/miscellaneous/misc.ts
+++ b/tests/miscellaneous/misc.ts
@@ -1,7 +1,7 @@
 import { ComponentFixture } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { DebugElement } from '@angular/core';
-import { filter, take } from 'rxjs/operators';
+import { debounceTime, filter, take } from 'rxjs/operators';
 
 import { TestComponentInterface } from '../scaffolding/testComponent';
 import { TestBedConfig } from '../scaffolding/runner';
@@ -145,11 +145,18 @@ export class Misc {
     this.scrollTo(999999);
   }
 
-  relaxNext(): Promise<void> {
+  relaxNext(debounce?: boolean): Promise<void> {
     return new Promise(resolve =>
-      this.adapter.isLoading$.pipe(
-        filter(pending => !pending),
-        take(1)
+      (debounce
+        ? this.adapter.isLoading$.pipe(
+          filter(pending => !pending),
+          debounceTime(30),
+          take(1)
+        )
+        : this.adapter.isLoading$.pipe(
+          filter(pending => !pending),
+          take(1)
+        )
       ).subscribe(() => resolve())
     );
   }

--- a/tests/scaffolding/templates.ts
+++ b/tests/scaffolding/templates.ts
@@ -58,7 +58,7 @@ export const generateTemplate = (templateSettings?: TemplateSettings): TemplateD
 ><div
   *uiScroll="let item of datasource; let index = index"
   [style]="${hasItemStyle ? 'getItemStyle(item)' : ''}"
-><span>{{index}}</span> : <b>{{item.text}}</b></div></div>`
+><span>{{index}}</span>: <b>{{item.text}}</b></div></div>`
   };
 };
 

--- a/tests/scroll-basic.spec.ts
+++ b/tests/scroll-basic.spec.ts
@@ -16,8 +16,8 @@ const configList: TestBedConfig[] = [{
   templateSettings: { viewportHeight: 66, itemHeight: 20 },
   custom: { direction: Direction.forward, count: 1 }
 }, {
-  datasourceSettings: { startIndex: 1, bufferSize: 5, padding: 1, horizontal: true, itemSize: 90 },
-  templateSettings: { viewportWidth: 450, itemWidth: 90, horizontal: true },
+  datasourceSettings: { startIndex: 1, bufferSize: 5, padding: 1, horizontal: true, itemSize: 100 },
+  templateSettings: { viewportWidth: 450, itemWidth: 100, horizontal: true },
   custom: { direction: Direction.forward, count: 1 }
 }, {
   datasourceSettings: { startIndex: -74, bufferSize: 4, padding: 0.72, horizontal: true, itemSize: 75 },


### PR DESCRIPTION
For issue #220.

## 1. Internal "relax" promise chain

The Adapter.relax method becomes chainable: running a random sequence of N "relax" methods will result in a chain of N promises running strictly one after the other.

Imagine we have 2 async processes that are sensitive to the Scroller's internal processes, and both want the Scroller to be relaxed before running the logic:

```js
async runProcessA() {
  await this.datasource.adapter.relax();
  ...
}
async runProcessB() {
  await this.datasource.adapter.relax();
  ...
}
```

Prior to this PR, there was possible to fall into a race condition between A and B, for example if both methods were called during the same UIScroll Workflow cycle, or even during the same javascript call stack. This PR handles such situation and provides an additional internal queue for any number of logical units (`...`) that are protected by the "Adapter.relax" promises.

## 2. Return value of "relax"

[As we know](https://dhilt.github.io/ngx-ui-scroll/#/adapter#return-value), each Adapter method returns a promise of

```ts
{
    success: boolean,
    immediate: boolean,
    details?: string
}
```

This PR makes it true also for the Adapter.relax method, and there is one important case where it might be very useful. Imagine the following sequence running in the same call stack:

```js
runProcessA()
Adapter.reload()
runProcessB()
```

Reload is not protected by "relax", we just want to interrupt the Scroller and stop all its activities. Scroller can't cancel the code following after the Adapter.relax promise, but it can tell that the flow was interrupted, it uses "success" field:

```js
async runProcessB() {
  const { success } = await this.datasource.adapter.relax();
  if (!success) {
    return; // we don't want to proceed if the Scroller has been reloaded
  }
  ...
}
```

So, if the App can reload the Scroller, I would suggest to use the Adapter-relax-success protection.