### PR TITLE
Reload via *ngIf: runtime exception and memory leak

### DIFF
--- a/demo/app/samples/test.component.html
+++ b/demo/app/samples/test.component.html
@@ -5,44 +5,51 @@
   <input [(ngModel)]="reloadIndex" style="width: 50px"> -
   <small>reload index</small>
   <br>
-  <button (click)="doReload()">Reload</button>
-  <button (click)="doPrepend()">Prepend</button>
-  <button (click)="doLog()">Show log</button>
+  <button (click)="doHideShow()">
+    <span *ngIf="show">Destroy</span>
+    <span *ngIf="!show">Create</span>
+  </button>
   <br>
-  <button (click)="doScrollHome()">Up</button>
-  <button (click)="doScrollEnd()">Down</button>
-  <button (click)="doScrollSome()">Some</button>
-  <br>
-  <input [(ngModel)]="sizeIndex" style="width: 50px">
-  <button (click)="doChangeSize()">Size</button>
-  <br>
-  <small>ngx-ui-scroll version: {{datasource.adapter.version}}</small>
-  <br>
-  <small>isLoading:
-    {{datasource.adapter.isLoading}}
-    ({{(datasource.adapter.isLoading$ | async)}})
-  </small>
-  <br>
-  <small>first visible:
-    {{datasource.adapter.firstVisible.$index}}
-    ({{(datasource.adapter.firstVisible$ | async)?.$index}})
-  </small>
-  <br>
-  <small>last visible:
-    {{datasource.adapter.lastVisible.$index}}
-    ({{(datasource.adapter.lastVisible$ | async)?.$index}})
-  </small>
-  <br>
-  <small>total:
-    {{datasource.adapter.itemsCount}},
-    visible:
-    {{getVisibleItemsCount()}}
-  </small>
+  <div *ngIf="show">
+    <button (click)="doReload()">Reload</button>
+    <button (click)="doPrepend()">Prepend</button>
+    <button (click)="doLog()">Show log</button>
+    <br>
+    <button (click)="doScrollHome()">Up</button>
+    <button (click)="doScrollEnd()">Down</button>
+    <button (click)="doScrollSome()">Some</button>
+    <br>
+    <input [(ngModel)]="sizeIndex" style="width: 50px">
+    <button (click)="doChangeSize()">Size</button>
+    <br>
+    <small>ngx-ui-scroll version: {{datasource.adapter.version}}</small>
+    <br>
+    <small>isLoading:
+      {{datasource.adapter.isLoading}}
+      ({{(datasource.adapter.isLoading$ | async)}})
+    </small>
+    <br>
+    <small>first visible:
+      {{datasource.adapter.firstVisible.$index}}
+      ({{(datasource.adapter.firstVisible$ | async)?.$index}})
+    </small>
+    <br>
+    <small>last visible:
+      {{datasource.adapter.lastVisible.$index}}
+      ({{(datasource.adapter.lastVisible$ | async)?.$index}})
+    </small>
+    <br>
+    <small>total:
+      {{datasource.adapter.itemsCount}},
+      visible:
+      {{getVisibleItemsCount()}}
+    </small>
+  </div>
   <br><br>
 </div>
 
 <div class="viewport" #viewport style="height: 600px" id="my-viewport">
-  <div>
+  <div *ngIf="show">
     <div
       *uiScroll="let item of datasource"
       (click)="doToggleItem(item)"

--- a/demo/app/samples/test.component.ts
+++ b/demo/app/samples/test.component.ts
@@ -133,6 +133,11 @@ export class TestComponent {
     }, delay);
   }
 
+  show = true;
+  doHideShow() {
+    this.show = !this.show;
+  }
+
   doReload() {
     this.datasource.adapter.reload(this.reloadIndex);
   }

--- a/package-dist.json
+++ b/package-dist.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-ui-scroll",
-  "version": "2.1.2",
+  "version": "2.2.0-beta",
   "description": "Infinite/virtual scroll for Angular",
   "main": "./bundles/ngx-ui-scroll.umd.js",
   "module": "./fesm5/ngx-ui-scroll.js",

--- a/package-dist.json
+++ b/package-dist.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-ui-scroll",
-  "version": "2.2.0-beta",
+  "version": "2.2.0-beta.1",
   "description": "Infinite/virtual scroll for Angular",
   "main": "./bundles/ngx-ui-scroll.umd.js",
   "module": "./fesm5/ngx-ui-scroll.js",

--- a/package-dist.json
+++ b/package-dist.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "tslib": "^1.9.0",
-    "vscroll": "^1.2.0-beta"
+    "vscroll": "^1.2.0"
   },
   "keywords": [
     "angular",

--- a/package-dist.json
+++ b/package-dist.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-ui-scroll",
-  "version": "2.2.0-beta.1",
+  "version": "2.2.0",
   "description": "Infinite/virtual scroll for Angular",
   "main": "./bundles/ngx-ui-scroll.umd.js",
   "module": "./fesm5/ngx-ui-scroll.js",

--- a/package-dist.json
+++ b/package-dist.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "tslib": "^1.9.0",
-    "vscroll": "^1.1.2"
+    "vscroll": "^1.2.0-beta"
   },
   "keywords": [
     "angular",

--- a/package-dist.json
+++ b/package-dist.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-ui-scroll",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Infinite/virtual scroll for Angular",
   "main": "./bundles/ngx-ui-scroll.umd.js",
   "module": "./fesm5/ngx-ui-scroll.js",
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "tslib": "^1.9.0",
-    "vscroll": "^1.1.0"
+    "vscroll": "^1.1.1"
   },
   "keywords": [
     "angular",

--- a/package-dist.json
+++ b/package-dist.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-ui-scroll",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "Infinite/virtual scroll for Angular",
   "main": "./bundles/ngx-ui-scroll.umd.js",
   "module": "./fesm5/ngx-ui-scroll.js",
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "tslib": "^1.9.0",
-    "vscroll": "^1.1.1"
+    "vscroll": "^1.1.2"
   },
   "keywords": [
     "angular",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13598,17 +13598,17 @@
       "dev": true
     },
     "vscroll": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/vscroll/-/vscroll-1.1.0.tgz",
-      "integrity": "sha512-MCBgQ2QLkWx1WoRLt6HOGTnXB6wbml/NYzjmOSWOelWucJVL/W+QJ3qFx9KlFF37w4UF5+O3ILxJtKxpvoRQ0g==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/vscroll/-/vscroll-1.1.1.tgz",
+      "integrity": "sha512-/kF7NwKNkud5ZUlbfEf0PvYK6DWZhhGy4MZG3U6AlKHf0hCbygEhZD7OVPKt+WdERrtUst/fCPk2WKIkPKzs0w==",
       "requires": {
         "tslib": "^2.1.0"
       },
       "dependencies": {
         "tslib": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
-          "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -13598,9 +13598,9 @@
       "dev": true
     },
     "vscroll": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/vscroll/-/vscroll-1.1.2.tgz",
-      "integrity": "sha512-aqJTrwNWw2OejPM2Olqfw75NaoAdwwxG6nnW1IWGIb5wEdvtlh5qgiyNGKF6XP5HQX1EIFwibETKGnTGJVkduA==",
+      "version": "1.2.0-beta",
+      "resolved": "https://registry.npmjs.org/vscroll/-/vscroll-1.2.0-beta.tgz",
+      "integrity": "sha512-s8keqPGcwdlYi6PYN4yBjE8wfAxi/BjNkcnKOYDnObKHf1s1BLo411n/LpDFgZgQjprtRpnUpQfNMV4GQA5OLA==",
       "requires": {
         "tslib": "^2.1.0"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -13598,9 +13598,9 @@
       "dev": true
     },
     "vscroll": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/vscroll/-/vscroll-1.1.1.tgz",
-      "integrity": "sha512-/kF7NwKNkud5ZUlbfEf0PvYK6DWZhhGy4MZG3U6AlKHf0hCbygEhZD7OVPKt+WdERrtUst/fCPk2WKIkPKzs0w==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vscroll/-/vscroll-1.1.2.tgz",
+      "integrity": "sha512-aqJTrwNWw2OejPM2Olqfw75NaoAdwwxG6nnW1IWGIb5wEdvtlh5qgiyNGKF6XP5HQX1EIFwibETKGnTGJVkduA==",
       "requires": {
         "tslib": "^2.1.0"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -13598,9 +13598,9 @@
       "dev": true
     },
     "vscroll": {
-      "version": "1.2.0-beta",
-      "resolved": "https://registry.npmjs.org/vscroll/-/vscroll-1.2.0-beta.tgz",
-      "integrity": "sha512-s8keqPGcwdlYi6PYN4yBjE8wfAxi/BjNkcnKOYDnObKHf1s1BLo411n/LpDFgZgQjprtRpnUpQfNMV4GQA5OLA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/vscroll/-/vscroll-1.2.0.tgz",
+      "integrity": "sha512-+oVgkePspoTkN1HvRwVst4y84jRqhZgdptxvZor2neba7ldljoVeNorZdZubMWMF11HTQvg8Weadfz70+NRCqA==",
       "requires": {
         "tslib": "^2.1.0"
       },

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "build-app": "ng build --configuration production",
     "deploy-app": "npm run build-app && firebase deploy",
     "preinstall": "cd server && npm install",
-    "pack:install": "npm run build && npm pack ./dist && npm install ngx-ui-scroll-2.1.2.tgz --no-save",
+    "pack:install": "npm run build && npm pack ./dist && npm install ngx-ui-scroll-2.2.0-beta.tgz --no-save",
     "pack:start": "npm run pack:install && npm start",
     "build": "node build.js",
     "publish:lib": "npm run build && npm publish ./dist",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "ngx-bootstrap": "^5.6.1",
     "rxjs": "~6.6.1",
     "tslib": "^1.13.0",
-    "vscroll": "^1.2.0-beta",
+    "vscroll": "^1.2.0",
     "zone.js": "~0.11.4"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "build-app": "ng build --configuration production",
     "deploy-app": "npm run build-app && firebase deploy",
     "preinstall": "cd server && npm install",
-    "pack:install": "npm run build && npm pack ./dist && npm install ngx-ui-scroll-2.1.1.tgz --no-save",
+    "pack:install": "npm run build && npm pack ./dist && npm install ngx-ui-scroll-2.1.2.tgz --no-save",
     "pack:start": "npm run pack:install && npm start",
     "build": "node build.js",
     "publish:lib": "npm run build && npm publish ./dist",
@@ -31,7 +31,7 @@
     "ngx-bootstrap": "^5.6.1",
     "rxjs": "~6.6.1",
     "tslib": "^1.13.0",
-    "vscroll": "^1.1.1",
+    "vscroll": "^1.1.2",
     "zone.js": "~0.11.4"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "build-app": "ng build --configuration production",
     "deploy-app": "npm run build-app && firebase deploy",
     "preinstall": "cd server && npm install",
-    "pack:install": "npm run build && npm pack ./dist && npm install ngx-ui-scroll-2.2.0-beta.1.tgz --no-save",
+    "pack:install": "npm run build && npm pack ./dist && npm install ngx-ui-scroll-2.2.0.tgz --no-save",
     "pack:start": "npm run pack:install && npm start",
     "build": "node build.js",
     "publish:lib": "npm run build && npm publish ./dist",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "ngx-bootstrap": "^5.6.1",
     "rxjs": "~6.6.1",
     "tslib": "^1.13.0",
-    "vscroll": "^1.1.2",
+    "vscroll": "^1.2.0-beta",
     "zone.js": "~0.11.4"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "build-app": "ng build --configuration production",
     "deploy-app": "npm run build-app && firebase deploy",
     "preinstall": "cd server && npm install",
-    "pack:install": "npm run build && npm pack ./dist && npm install ngx-ui-scroll-2.2.0-beta.tgz --no-save",
+    "pack:install": "npm run build && npm pack ./dist && npm install ngx-ui-scroll-2.2.0-beta.1.tgz --no-save",
     "pack:start": "npm run pack:install && npm start",
     "build": "node build.js",
     "publish:lib": "npm run build && npm publish ./dist",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "build-app": "ng build --configuration production",
     "deploy-app": "npm run build-app && firebase deploy",
     "preinstall": "cd server && npm install",
-    "pack:install": "npm run build && npm pack ./dist && npm install ngx-ui-scroll-2.1.0.tgz --no-save",
+    "pack:install": "npm run build && npm pack ./dist && npm install ngx-ui-scroll-2.1.1.tgz --no-save",
     "pack:start": "npm run pack:install && npm start",
     "build": "node build.js",
     "publish:lib": "npm run build && npm publish ./dist",
@@ -31,7 +31,7 @@
     "ngx-bootstrap": "^5.6.1",
     "rxjs": "~6.6.1",
     "tslib": "^1.13.0",
-    "vscroll": "^1.1.0",
+    "vscroll": "^1.1.1",
     "zone.js": "~0.11.4"
   },
   "devDependencies": {

--- a/src/ui-scroll.component.ts
+++ b/src/ui-scroll.component.ts
@@ -63,6 +63,9 @@ export class UiScrollComponent<Data = unknown> implements OnInit, OnDestroy {
 
   ngOnDestroy(): void {
     this.workflow.dispose();
-    (this.datasource as unknown as { reset: () => void }).reset();
+    const { reset } = (this.datasource as unknown as { reset?: () => void });
+    if (typeof reset === 'function') {
+      reset.call(this.datasource);
+    }
   }
 }

--- a/src/ui-scroll.component.ts
+++ b/src/ui-scroll.component.ts
@@ -50,7 +50,7 @@ export class UiScrollComponent<Data = unknown> implements OnInit, OnDestroy {
     this.workflow = new Workflow<Data>({
       consumer,
       element: this.elementRef.nativeElement,
-      datasource: this.datasource as unknown as IDatasource<Data>,
+      datasource: this.datasource as IDatasource<Data>,
       run: items => {
         if (!items.length && !this.items.length) {
           return;
@@ -63,5 +63,6 @@ export class UiScrollComponent<Data = unknown> implements OnInit, OnDestroy {
 
   ngOnDestroy(): void {
     this.workflow.dispose();
+    (this.datasource as unknown as { reset: () => void }).reset();
   }
 }

--- a/src/ui-scroll.component.ts
+++ b/src/ui-scroll.component.ts
@@ -63,9 +63,5 @@ export class UiScrollComponent<Data = unknown> implements OnInit, OnDestroy {
 
   ngOnDestroy(): void {
     this.workflow.dispose();
-    const { reset } = (this.datasource as unknown as { reset?: () => void });
-    if (typeof reset === 'function') {
-      reset.call(this.datasource);
-    }
   }
 }

--- a/src/ui-scroll.datasource.ts
+++ b/src/ui-scroll.datasource.ts
@@ -59,11 +59,11 @@ const getAdapterConfig = (): IAdapterConfig => ({
 });
 
 const makeAngularDatasource = () => class <T = unknown> implements IAngularDatasourceConstructed<T> {
-  get: IDatasource<T>['get'];
-  settings?: IDatasource<T>['settings'];
-  devSettings?: IDatasource<T>['devSettings'];
+  get: IAngularDatasource<T>['get'];
+  settings?: IAngularDatasource<T>['settings'];
+  devSettings?: IAngularDatasource<T>['devSettings'];
   adapter: IAngularAdapter<T>;
-  constructor(_ds: IDatasource<T>) { }
+  constructor(_ds: IAngularDatasource<T>) { }
 };
 
 const AngularDatasource =

--- a/src/ui-scroll.version.ts
+++ b/src/ui-scroll.version.ts
@@ -1,4 +1,4 @@
 export default {
   name: 'ngx-ui-scroll',
-  version: '2.1.0'
+  version: '2.1.1'
 };

--- a/src/ui-scroll.version.ts
+++ b/src/ui-scroll.version.ts
@@ -1,4 +1,4 @@
 export default {
   name: 'ngx-ui-scroll',
-  version: '2.1.2'
+  version: '2.2.0-beta'
 };

--- a/src/ui-scroll.version.ts
+++ b/src/ui-scroll.version.ts
@@ -1,4 +1,4 @@
 export default {
   name: 'ngx-ui-scroll',
-  version: '2.2.0-beta'
+  version: '2.2.0-beta.1'
 };

--- a/src/ui-scroll.version.ts
+++ b/src/ui-scroll.version.ts
@@ -1,4 +1,4 @@
 export default {
   name: 'ngx-ui-scroll',
-  version: '2.1.1'
+  version: '2.1.2'
 };

--- a/src/ui-scroll.version.ts
+++ b/src/ui-scroll.version.ts
@@ -1,4 +1,4 @@
 export default {
   name: 'ngx-ui-scroll',
-  version: '2.2.0-beta.1'
+  version: '2.2.0'
 };

--- a/tests/_index.js
+++ b/tests/_index.js
@@ -47,6 +47,7 @@ const testContext = require.context(
   //(eof)\.spec\.ts/
   //(initial-load)\.spec\.ts/
   //(min-max-indexes)\.spec\.ts/
+  //(recreation)\.spec\.ts/
   //(scroll-basic)\.spec\.ts/
   //(scroll-delay)\.spec\.ts/
   //(scroll-fast)\.spec\.ts/

--- a/tests/adapter.reload.spec.ts
+++ b/tests/adapter.reload.spec.ts
@@ -291,10 +291,11 @@ const shouldReloadOnFirstVisibleChange: ItFuncConfig<ICustom> = config => misc =
       lastCycle = misc.workflow.cyclesDone + 1;
     }
   });
-  misc.adapter.isLoading$.pipe(filter(v => !v)).subscribe(() => {
+  const sub2 = misc.adapter.isLoading$.pipe(filter(v => !v)).subscribe(() => {
     if (!stopScroll) {
       misc.scrollMin();
     } else if (misc.workflow.cyclesDone === lastCycle) {
+      sub2.unsubscribe();
       checkExpectation(config, misc);
       done();
     }
@@ -302,8 +303,6 @@ const shouldReloadOnFirstVisibleChange: ItFuncConfig<ICustom> = config => misc =
 };
 
 describe('Adapter Reload Spec', () => {
-
-  // configListDestructiveFilter(configList, 0);
 
   describe('simple reload', () =>
     configList.forEach(config =>

--- a/tests/adapter.reload.spec.ts
+++ b/tests/adapter.reload.spec.ts
@@ -190,13 +190,14 @@ const shouldReload: ItFuncConfig<ICustom> = config => misc => done => {
       }
     });
   }
-  misc.adapter.isLoading$.pipe(filter(v => !v)).subscribe(() => {
+  const sub = misc.adapter.isLoading$.pipe(filter(v => !v)).subscribe(() => {
     if (misc.workflow.cyclesDone < startWFCount + config.custom.scrollCount) {
       misc.scrollMax();
     } else if (misc.workflow.cyclesDone === startWFCount + config.custom.scrollCount) {
       doReload(config, misc);
     } else {
       checkExpectation(config, misc);
+      sub.unsubscribe();
       done();
     }
   });
@@ -301,6 +302,8 @@ const shouldReloadOnFirstVisibleChange: ItFuncConfig<ICustom> = config => misc =
 };
 
 describe('Adapter Reload Spec', () => {
+
+  // configListDestructiveFilter(configList, 0);
 
   describe('simple reload', () =>
     configList.forEach(config =>

--- a/tests/bug.spec.ts
+++ b/tests/bug.spec.ts
@@ -1,10 +1,11 @@
 import { makeTest, TestBedConfig } from './scaffolding/runner';
-import { configureTestBedSub } from './scaffolding/testBed';
 import { DatasourceProcessor } from './scaffolding/datasources/class';
-import { ScrollerSubTestComponent } from './scaffolding/testComponent';
 import { IndexedItem, removeItems } from './miscellaneous/items';
 import { Misc } from './miscellaneous/misc';
 import { ItemAdapter } from './miscellaneous/vscroll';
+
+import { configureTestBedSub, configureTestBedNgIf } from './scaffolding/testBed';
+import { ScrollerSubTestComponent, ScrollerNgIfTestComponent } from './scaffolding/testComponent';
 
 describe('Bug Spec', () => {
 
@@ -121,9 +122,7 @@ describe('Bug Spec', () => {
   describe('early (constructor) subscriptions', () => {
     let misc: Misc<ScrollerSubTestComponent>;
 
-    beforeEach(() => {
-      misc = new Misc(configureTestBedSub());
-    });
+    beforeEach(() => misc = new Misc(configureTestBedSub()));
 
     it('should work', async () => {
       const { adapter, testComponent } = misc;
@@ -284,5 +283,27 @@ describe('Bug Spec', () => {
       }
     })
   );
+
+  describe('reload via ngIf', () => {
+    let misc: Misc<ScrollerNgIfTestComponent>;
+
+    beforeEach((() => {
+      misc = new Misc(configureTestBedNgIf());
+    }));
+
+    it('should work', done => {
+      let count = 0;
+      misc.adapter.init$.subscribe(init => {
+        if (init) {
+          count++;
+        }
+        console.log('COUNT', count, init);
+        if (count === 2) {
+          console.log('show');
+          done();
+        }
+      });
+    });
+  });
 
 });

--- a/tests/bug.spec.ts
+++ b/tests/bug.spec.ts
@@ -1,5 +1,3 @@
-import { filter, take } from 'rxjs/operators';
-
 import { makeTest, TestBedConfig } from './scaffolding/runner';
 import { DatasourceProcessor } from './scaffolding/datasources/class';
 import { IndexedItem, removeItems } from './miscellaneous/items';
@@ -285,89 +283,5 @@ describe('Bug Spec', () => {
       }
     })
   );
-
-  describe('reload via ngIf', () => {
-    let misc: Misc<ScrollerSubTestComponent>;
-    let scrollerId: number;
-    let adapterId: number;
-
-    beforeEach(() => {
-      misc = new Misc(configureTestBedSub());
-      scrollerId = misc.scroller.settings.instanceIndex;
-      adapterId = misc.adapter.id;
-    });
-
-    const init = (flag: boolean): Promise<boolean> =>
-      misc.testComponent.datasource.adapter.init$.pipe(
-        filter(v => flag ? v : !v), take(1)
-      ).toPromise();
-
-    const ngIfReload = async (onBeforeHide?: () => void): Promise<void> => {
-      await init(true);
-      await misc.adapter.relax();
-      onBeforeHide && onBeforeHide();
-      misc.testComponent.show = false;
-      await init(false);
-      misc.testComponent.show = true;
-      misc.fixture.changeDetectorRef.detectChanges();
-      await init(true);
-    };
-
-    it('should switch Adapter.init trice', async () => {
-      let count = 0;
-      const result = new Promise(resolve => {
-        const sub = misc.testComponent.datasource.adapter.init$.subscribe(() => {
-          if (++count === 3) {
-            sub.unsubscribe();
-            resolve(null);
-          }
-        });
-      });
-      await ngIfReload();
-      await result;
-      expect(count).toBe(3);
-    });
-
-    it('should re-render the viewport', async () => {
-      expect(misc.workflow.isInitialized).toEqual(false);
-      expect(misc.adapter.id).toEqual(adapterId);
-      const _scroller = misc.scroller;
-      expect(_scroller.settings.instanceIndex).toEqual(scrollerId);
-      await ngIfReload();
-      const wf = misc.getWorkflow();
-      const scroller = wf.scroller;
-      expect(_scroller).not.toEqual(scroller);
-      expect(wf.isInitialized).toEqual(true);
-      expect(misc.adapter.id).toEqual(adapterId);
-      expect(scroller.adapter.id).toEqual(adapterId);
-      expect(scroller.settings.instanceIndex).toEqual(scrollerId + 1);
-    });
-
-    it('should scroll and take firstVisible', async () => {
-      await ngIfReload();
-      await misc.adapter.relax();
-      const { firstVisible, firstVisible$ } = misc.adapter;
-      expect(firstVisible.$index).toEqual(1);
-      await misc.scrollMaxRelax();
-      expect(misc.adapter.firstVisible$).toEqual(firstVisible$);
-      expect(misc.adapter.firstVisible.$index).toBeGreaterThan(1);
-    });
-
-    it('should clear Buffer', async () => {
-      let retainedBuffer, retainedItem;
-      await ngIfReload(() => {
-        retainedBuffer = misc.scroller.buffer;
-        retainedItem = retainedBuffer.items[0];
-        expect(retainedBuffer.size).not.toBe(0);
-        expect(retainedItem.element).toBeTruthy();
-      });
-      await misc.adapter.relax();
-      const buffer = misc.getWorkflow().scroller.buffer;
-      expect((retainedBuffer as unknown as { size: number }).size).toBe(0);
-      expect((retainedItem as unknown as { element?: HTMLElement }).element).toBeFalsy();
-      expect(buffer.size).not.toBe(0);
-      expect(buffer.items[0].element).toBeTruthy();
-    });
-  });
 
 });

--- a/tests/common.spec.ts
+++ b/tests/common.spec.ts
@@ -265,6 +265,8 @@ describe('Datasource', () => {
         get(_offset: number, _count: number) {
           return [];
         }
+
+        reset() { }
       }
     },
     title: 'should pass',
@@ -314,7 +316,7 @@ describe('Workflow & Adapter', () => {
     it('should pass', done => {
       setTimeout(() => {
         misc.fixture.destroy();
-        expect(misc.workflow.isInitialized).toBe(false);
+        expect(misc.workflow.isInitialized).toBeFalsy();
         expect(misc.adapter.init).toBe(false);
         done();
       }, delay);
@@ -326,7 +328,7 @@ describe('Workflow & Adapter', () => {
 
     it('should dispose correctly', done => {
       misc.fixture.destroy();
-      expect(misc.workflow.isInitialized).toBe(false);
+      expect(misc.workflow.isInitialized).toBeFalsy();
       expect(misc.adapter.init).toBe(false);
       done();
     });
@@ -339,7 +341,7 @@ describe('Workflow & Adapter', () => {
       expect(misc.workflow.isInitialized).toBe(true);
       expect(misc.adapter.init).toBe(true);
       misc.fixture.destroy();
-      expect(misc.workflow.isInitialized).toBe(false);
+      expect(misc.workflow.isInitialized).toBeFalsy();
       expect(misc.adapter.init).toBe(false);
       done();
     });
@@ -350,7 +352,6 @@ describe('Workflow & Adapter', () => {
 describe('Multiple Instances', () => {
 
   let fixture: ComponentFixture<TwoScrollersTestComponent>;
-  let reconfigure = true;
   const getAdapters = (): { a1: IAdapter<Data>, a2: IAdapter<Data> } => ({
     a1: fixture.componentInstance.datasource.adapter,
     a2: fixture.componentInstance.datasource2.adapter
@@ -365,13 +366,7 @@ describe('Multiple Instances', () => {
 
   describe('Initialization', () => {
 
-    beforeEach(waitForAsync(() => {
-      if (!reconfigure) {
-        return;
-      }
-      reconfigure = false;
-      fixture = configureTestBedTwo();
-    }));
+    beforeEach((() => fixture = configureTestBedTwo()));
 
     it('should init component with 2 datasources', () => {
       const cmp = fixture.componentInstance;

--- a/tests/miscellaneous/common.ts
+++ b/tests/miscellaneous/common.ts
@@ -1,15 +1,13 @@
 import { TestBedConfig } from '../scaffolding/runner';
 
-type Item<T = unknown> = T;
-
-export const destructiveFilter = <T>(list: Item<T>[], predicate: (item: Item<T>, index?: number) => boolean): void =>
+const destructiveFilter = <T>(list: T[], predicate: (item: T, index?: number) => boolean): void =>
   Array.from(Array(list.length).keys()).reverse().forEach(index =>
     predicate(list[index], index) && list.splice(index, 1)
   );
 
 // remove all non-filterIndex items in-place
-export const configListDestructiveFilter = (configList: Item<TestBedConfig>[], filterIndex: number): void =>
-  destructiveFilter(configList, (item, index) =>
+export const configListDestructiveFilter = (list: unknown[], filterIndex: number): void =>
+  destructiveFilter(list as TestBedConfig[], (item, index) =>
     !!(item.datasourceDevSettings = { debug: true, logProcessRun: true, immediateLog: true }) &&
     !!(item.timeout = 9000) &&
     index !== filterIndex

--- a/tests/miscellaneous/misc.ts
+++ b/tests/miscellaneous/misc.ts
@@ -82,6 +82,10 @@ export class Misc<Comp = TestComponentInterface> {
     };
   }
 
+  getWorkflow(): Workflow<Data> {
+    return this.fixture.debugElement.query(By.css('[ui-scroll]')).componentInstance.workflow;
+  }
+
   generateFakeWorkflow(settings?: Scroller['settings']): Workflow {
     return new Workflow({
       consumer: { name: 'fake', version: 'x.x.x' },
@@ -152,7 +156,7 @@ export class Misc<Comp = TestComponentInterface> {
   }
 
   scrollTo(value: number): void {
-    this.scroller.adapter.fix({ scrollPosition: value });
+    this.adapter.fix({ scrollPosition: value });
   }
 
   scrollMin(): void {

--- a/tests/miscellaneous/misc.ts
+++ b/tests/miscellaneous/misc.ts
@@ -82,8 +82,12 @@ export class Misc<Comp = TestComponentInterface> {
     };
   }
 
+  getComponent(): UiScrollComponent<Data> {
+    return this.fixture.debugElement.query(By.css('[ui-scroll]')).componentInstance;
+  }
+
   getWorkflow(): Workflow<Data> {
-    return this.fixture.debugElement.query(By.css('[ui-scroll]')).componentInstance.workflow;
+    return this.getComponent().workflow;
   }
 
   generateFakeWorkflow(settings?: Scroller['settings']): Workflow {

--- a/tests/recreation.spec.ts
+++ b/tests/recreation.spec.ts
@@ -1,0 +1,112 @@
+import { filter, take } from 'rxjs/operators';
+
+import { Misc } from './miscellaneous/misc';
+
+import { configureTestBedSub, configureTestBedPlain } from './scaffolding/testBed';
+import { ScrollerSubTestComponent, ScrollerPlainTestComponent } from './scaffolding/testComponent';
+
+describe('Recreation Spec', () => {
+
+  describe('Destroying (plain DS)', () => {
+    let misc: Misc<ScrollerPlainTestComponent>;
+
+    beforeEach(() => {
+      misc = new Misc(configureTestBedPlain());
+    });
+
+    it('should not reset Datasource on destroy', async () => {
+      misc.fixture.destroy();
+      await misc.delay(25);
+    });
+
+    it('should not reset Datasource on destroy via ngIf', async () => {
+      await misc.delay(25);
+      misc.testComponent.show = false;
+      await misc.delay(25);
+    });
+  });
+
+  describe('Recreation via ngIf (instance DS)', () => {
+    let misc: Misc<ScrollerSubTestComponent>;
+    let scrollerId: number;
+    let adapterId: number;
+
+    beforeEach(() => {
+      misc = new Misc(configureTestBedSub());
+      scrollerId = misc.scroller.settings.instanceIndex;
+      adapterId = misc.adapter.id;
+    });
+
+    const init = (flag: boolean): Promise<boolean> =>
+      misc.testComponent.datasource.adapter.init$.pipe(
+        filter(v => flag ? v : !v), take(1)
+      ).toPromise();
+
+    const ngIfReload = async (onBeforeHide?: () => void): Promise<void> => {
+      await init(true);
+      await misc.adapter.relax();
+      onBeforeHide && onBeforeHide();
+      misc.testComponent.show = false;
+      await init(false);
+      misc.testComponent.show = true;
+      misc.fixture.changeDetectorRef.detectChanges();
+      await init(true);
+    };
+
+    it('should switch Adapter.init trice', async () => {
+      let count = 0;
+      const result = new Promise(resolve => {
+        const sub = misc.testComponent.datasource.adapter.init$.subscribe(() => {
+          if (++count === 3) {
+            sub.unsubscribe();
+            resolve(null);
+          }
+        });
+      });
+      await ngIfReload();
+      await result;
+      expect(count).toBe(3);
+    });
+
+    it('should re-render the viewport', async () => {
+      expect(misc.workflow.isInitialized).toEqual(false);
+      expect(misc.adapter.id).toEqual(adapterId);
+      const _scroller = misc.scroller;
+      expect(_scroller.settings.instanceIndex).toEqual(scrollerId);
+      await ngIfReload();
+      const wf = misc.getWorkflow();
+      const scroller = wf.scroller;
+      expect(_scroller).not.toEqual(scroller);
+      expect(wf.isInitialized).toEqual(true);
+      expect(misc.adapter.id).toEqual(adapterId);
+      expect(scroller.adapter.id).toEqual(adapterId);
+      expect(scroller.settings.instanceIndex).toEqual(scrollerId + 1);
+    });
+
+    it('should scroll and take firstVisible', async () => {
+      await ngIfReload();
+      await misc.adapter.relax();
+      const { firstVisible, firstVisible$ } = misc.adapter;
+      expect(firstVisible.$index).toEqual(1);
+      await misc.scrollMaxRelax();
+      expect(misc.adapter.firstVisible$).toEqual(firstVisible$);
+      expect(misc.adapter.firstVisible.$index).toBeGreaterThan(1);
+    });
+
+    it('should clear Buffer', async () => {
+      let retainedBuffer, retainedItem;
+      await ngIfReload(() => {
+        retainedBuffer = misc.scroller.buffer;
+        retainedItem = retainedBuffer.items[0];
+        expect(retainedBuffer.size).not.toBe(0);
+        expect(retainedItem.element).toBeTruthy();
+      });
+      await misc.adapter.relax();
+      const buffer = misc.getWorkflow().scroller.buffer;
+      expect((retainedBuffer as unknown as { size: number }).size).toBe(0);
+      expect((retainedItem as unknown as { element?: HTMLElement }).element).toBeFalsy();
+      expect(buffer.size).not.toBe(0);
+      expect(buffer.items[0].element).toBeTruthy();
+    });
+  });
+});

--- a/tests/scaffolding/testBed.ts
+++ b/tests/scaffolding/testBed.ts
@@ -9,7 +9,6 @@ import {
   ScrollerTestComponent,
   TwoScrollersTestComponent,
   ScrollerSubTestComponent,
-  ScrollerNgIfTestComponent,
 } from './testComponent';
 
 export const configureTestBed = (
@@ -45,4 +44,3 @@ const configureTestBedFactory = <T>(comp: Type<T>) => (): ComponentFixture<T> =>
 
 export const configureTestBedTwo = configureTestBedFactory(TwoScrollersTestComponent);
 export const configureTestBedSub = configureTestBedFactory(ScrollerSubTestComponent);
-export const configureTestBedNgIf = configureTestBedFactory(ScrollerNgIfTestComponent);

--- a/tests/scaffolding/testBed.ts
+++ b/tests/scaffolding/testBed.ts
@@ -9,6 +9,7 @@ import {
   ScrollerTestComponent,
   TwoScrollersTestComponent,
   ScrollerSubTestComponent,
+  ScrollerPlainTestComponent,
 } from './testComponent';
 
 export const configureTestBed = (
@@ -44,3 +45,4 @@ const configureTestBedFactory = <T>(comp: Type<T>) => (): ComponentFixture<T> =>
 
 export const configureTestBedTwo = configureTestBedFactory(TwoScrollersTestComponent);
 export const configureTestBedSub = configureTestBedFactory(ScrollerSubTestComponent);
+export const configureTestBedPlain = configureTestBedFactory(ScrollerPlainTestComponent);

--- a/tests/scaffolding/testBed.ts
+++ b/tests/scaffolding/testBed.ts
@@ -5,7 +5,12 @@ import { Type } from '@angular/core';
 import { UiScrollModule } from '../../src/ui-scroll.module';
 
 import { DatasourceService } from './datasources/class';
-import { ScrollerTestComponent, TwoScrollersTestComponent, ScrollerSubTestComponent } from './testComponent';
+import {
+  ScrollerTestComponent,
+  TwoScrollersTestComponent,
+  ScrollerSubTestComponent,
+  ScrollerNgIfTestComponent,
+} from './testComponent';
 
 export const configureTestBed = (
   datasource: new () => unknown, template: string
@@ -40,3 +45,4 @@ const configureTestBedFactory = <T>(comp: Type<T>) => (): ComponentFixture<T> =>
 
 export const configureTestBedTwo = configureTestBedFactory(TwoScrollersTestComponent);
 export const configureTestBedSub = configureTestBedFactory(ScrollerSubTestComponent);
+export const configureTestBedNgIf = configureTestBedFactory(ScrollerNgIfTestComponent);

--- a/tests/scaffolding/testComponent.ts
+++ b/tests/scaffolding/testComponent.ts
@@ -8,7 +8,6 @@ import { IDatasource, Datasource } from '../../src/ui-scroll.datasource';
 
 import { DatasourceService } from './datasources/class';
 import { defaultTemplate, TemplateSettings } from './templates';
-import { filter, take } from 'rxjs/operators';
 
 export interface TestComponentInterface {
   datasource: IDatasource<Data>;
@@ -80,6 +79,7 @@ export class TwoScrollersTestComponent implements TestComponentInterface {
 
 @Component({
   template: `<div
+  *ngIf="show"
   style="height: 200px; overflow-y: scroll;"
 ><div
   *uiScroll="let item of datasource; let index = index"
@@ -90,52 +90,15 @@ export class ScrollerSubTestComponent implements TestComponentInterface {
     get: (index, count, success) =>
       success(Array.from({ length: count }, (j, i) =>
         ({ id: i + index, text: 'item #' + (i + index) })
-      ))
-  });
-
-  firstVisible: ItemAdapter<Data>;
-
-  constructor() {
-    this.datasource.adapter.firstVisible$.subscribe(value => this.firstVisible = value);
-  }
-}
-
-@Component({
-  template: `<div
-  *ngIf="show"
-  style="height: 200px; overflow-y: scroll;"
-><div
-  *uiScroll="let item of datasource; let index = index"
-><span>{{index}}</span> : <b>{{item.text}}</b></div></div>`
-})
-export class ScrollerNgIfTestComponent implements TestComponentInterface {
-  datasource = new Datasource<Data>({
-    get: (index, count, success) =>
-      success(Array.from({ length: count }, (j, i) =>
-        ({ id: i + index, text: 'item #' + (i + index) })
       )),
-    devSettings: { debug: true }
+    // devSettings: { debug: true }
   });
 
   show: boolean;
+  firstVisible: ItemAdapter<Data>;
 
   constructor() {
     this.show = true;
-    this.run();
-  }
-
-  init(flag: boolean): Promise<boolean> {
-    return this.datasource.adapter.init$.pipe(
-      filter(v => flag ? v : !v), take(1)
-    ).toPromise();
-  }
-
-  async run(): Promise<void> {
-    await this.init(true);
-    await this.datasource.adapter.relax();
-    this.show = false;
-    await this.init(false);
-    this.show = true;
-    await this.init(true);
+    this.datasource.adapter.firstVisible$.subscribe(value => this.firstVisible = value);
   }
 }

--- a/tests/scaffolding/testComponent.ts
+++ b/tests/scaffolding/testComponent.ts
@@ -77,28 +77,35 @@ export class TwoScrollersTestComponent implements TestComponentInterface {
   });
 }
 
-@Component({
-  template: `<div
+const basicTemplate = `<div
   *ngIf="show"
   style="height: 200px; overflow-y: scroll;"
 ><div
   *uiScroll="let item of datasource; let index = index"
-><span>{{index}}</span> : <b>{{item.text}}</b></div></div>`
-})
+><span>{{index}}</span> : <b>{{item.text}}</b></div></div>`;
+
+const basicDS: IDatasource<Data> = {
+  get: (index, count, success) =>
+    success(Array.from({ length: count }, (j, i) =>
+      ({ id: i + index, text: 'item #' + (i + index) })
+    )),
+  // devSettings: { debug: true }
+};
+
+@Component({ template: basicTemplate })
 export class ScrollerSubTestComponent implements TestComponentInterface {
-  datasource = new Datasource<Data>({
-    get: (index, count, success) =>
-      success(Array.from({ length: count }, (j, i) =>
-        ({ id: i + index, text: 'item #' + (i + index) })
-      )),
-    // devSettings: { debug: true }
-  });
-
-  show: boolean;
+  datasource = new Datasource<Data>(basicDS);
+  show = true;
   firstVisible: ItemAdapter<Data>;
-
   constructor() {
-    this.show = true;
     this.datasource.adapter.firstVisible$.subscribe(value => this.firstVisible = value);
+  }
+}
+
+@Component({ template: basicTemplate })
+export class ScrollerPlainTestComponent implements TestComponentInterface {
+  datasource = basicDS;
+  show = true;
+  constructor() {
   }
 }


### PR DESCRIPTION
Based on [Memory leak when using Datasource class instance](https://github.com/dhilt/ngx-ui-scroll/issues/276) issue. 

TODO

- [x] spec for "Cannot redefine property" exception
- [x] spec for retained objects situation
- [x] bump vscroll version after fixing redefine problem on vscroll's end
- [x] release interim ngx-ui-scroll version (2.1.2)
- [x] bump vscroll version after fixing memory leak on vscroll's end
- [x] release new ngx-ui-scroll version (2.2.0-beta)
- [x] refactor, clean up and release ngx-ui-scroll v2.2.0