### PR TITLE
fix: export types used by the `Datasource` class

### DIFF
--- a/scroller/public-api.ts
+++ b/scroller/public-api.ts
@@ -1,5 +1,11 @@
 export { UiScrollModule } from './src/ui-scroll.module';
 export { UiScrollDirective } from './src/ui-scroll.directive';
 export { Datasource } from './src/ui-scroll.datasource';
-export { IAdapter, IDatasource } from './src/types';
+export {
+  RoutinesClassType,
+  IAdapter,
+  IDatasource,
+  IAngularDatasourceParams,
+  IAngularDatasourceConstructed
+} from './src/types';
 export { Routines, SizeStrategy } from './src/vscroll';

--- a/scroller/src/types.ts
+++ b/scroller/src/types.ts
@@ -28,7 +28,7 @@ interface IAngularAdapter<Data = unknown>
   extends _Omit<IAdapter<Data>, keyof IReactiveOverride<Data>>,
     IReactiveOverride<Data> {}
 
-interface IAngularDatasourceParams<Data = unknown>
+export interface IAngularDatasourceParams<Data = unknown>
   extends _Omit<IDatasource<Data>, 'adapter'> {}
 
 interface IAngularDatasource<Data = unknown>
@@ -36,7 +36,7 @@ interface IAngularDatasource<Data = unknown>
   adapter?: IAngularAdapter<Data>;
 }
 
-interface IAngularDatasourceConstructed<Data = unknown>
+export interface IAngularDatasourceConstructed<Data = unknown>
   extends _Omit<IDatasourceConstructed<Data>, 'adapter'> {
   adapter: IAngularAdapter<Data>;
 }


### PR DESCRIPTION
We need to export these interfaces because they are used by the compiler, so they should be exposed publicly from the module entry point.

![image](https://github.com/dhilt/ngx-ui-scroll/assets/7337691/a26f7416-d15d-4445-8456-202074ae4fd7)
